### PR TITLE
fix(ci): main-CI grün — render_stack Sort-Bug + config (F4)

### DIFF
--- a/.github/scripts/bootstrap_labels.py
+++ b/.github/scripts/bootstrap_labels.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """Usage: python .github/scripts/bootstrap_labels.py --repo owner/repo --token $GITHUB_TOKEN"""
-import argparse, requests
+
+import argparse
+import requests
 
 LABELS = [
-    {"name": "bug",           "color": "d73a4a", "description": "Fehler"},
-    {"name": "enhancement",   "color": "a2eeef", "description": "Neue Funktion"},
-    {"name": "task",          "color": "e4e669", "description": "Technische Aufgabe"},
-    {"name": "triage",        "color": "e99695", "description": "Neu, nicht bewertet"},
+    {"name": "bug", "color": "d73a4a", "description": "Fehler"},
+    {"name": "enhancement", "color": "a2eeef", "description": "Neue Funktion"},
+    {"name": "task", "color": "e4e669", "description": "Technische Aufgabe"},
+    {"name": "triage", "color": "e99695", "description": "Neu, nicht bewertet"},
     {"name": "documentation", "color": "0075ca", "description": "Dokumentation"},
-    {"name": "dependencies",  "color": "0366d6", "description": "Dependency Update"},
+    {"name": "dependencies", "color": "0366d6", "description": "Dependency Update"},
 ]
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -17,14 +20,25 @@ def main():
     parser.add_argument("--token", required=True)
     args = parser.parse_args()
     session = requests.Session()
-    session.headers.update({"Authorization": f"Bearer {args.token}", "Accept": "application/vnd.github+json"})
-    existing = {l["name"] for l in session.get(f"https://api.github.com/repos/{args.repo}/labels", params={"per_page": 100}).json()}
+    session.headers.update(
+        {"Authorization": f"Bearer {args.token}", "Accept": "application/vnd.github+json"}
+    )
+    existing = {
+        lbl["name"]
+        for lbl in session.get(
+            f"https://api.github.com/repos/{args.repo}/labels", params={"per_page": 100}
+        ).json()
+    }
     for label in LABELS:
         if label["name"] in existing:
-            session.patch(f"https://api.github.com/repos/{args.repo}/labels/{requests.utils.quote(label['name'])}", json=label)
+            session.patch(
+                f"https://api.github.com/repos/{args.repo}/labels/{requests.utils.quote(label['name'])}",
+                json=label,
+            )
         else:
             session.post(f"https://api.github.com/repos/{args.repo}/labels", json=label)
         print(f"ok: {label['name']}")
+
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -38,7 +38,7 @@ jobs:
       - name: Install package + dev deps
         run: |
           pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,django]"
       - name: Run tests with coverage
         run: pytest tests/ -v --tb=short --cov --cov-report=term-missing
       - name: Coverage gate (≥80%)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -22,6 +22,6 @@ jobs:
       - name: Install package + dev deps
         run: |
           pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,django]"
       - name: Run tests
         run: pytest tests/ -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-mock>=3.12",
+    "pytest-cov>=5.0",
     "tiktoken>=0.6",
 ]
 testing = [

--- a/src/promptfw/contrib/django/admin.py
+++ b/src/promptfw/contrib/django/admin.py
@@ -100,9 +100,7 @@ class PromptTemplateAdmin(admin.ModelAdmin):
         for ac in action_codes:
             invalidate_cache(ac)
 
-    @admin.action(
-        description=_("Create new version (copy with incremented version)")
-    )
+    @admin.action(description=_("Create new version (copy with incremented version)"))
     def create_new_version(self, request, queryset):
         count = 0
         for tpl in queryset.filter(is_active=True):

--- a/src/promptfw/contrib/django/management/commands/export_prompts.py
+++ b/src/promptfw/contrib/django/management/commands/export_prompts.py
@@ -68,9 +68,7 @@ class Command(BaseCommand):
         else:
             self._export_directory(templates, Path(output_dir))
 
-        self.stdout.write(
-            self.style.SUCCESS(f"Exported {len(templates)} prompt template(s).")
-        )
+        self.stdout.write(self.style.SUCCESS(f"Exported {len(templates)} prompt template(s)."))
 
     def _template_to_dict(self, tpl: PromptTemplate) -> dict:
         """Convert a PromptTemplate to a serializable dict."""

--- a/src/promptfw/contrib/django/management/commands/seed_prompts.py
+++ b/src/promptfw/contrib/django/management/commands/seed_prompts.py
@@ -10,7 +10,6 @@ import yaml
 from pathlib import Path
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.translation import gettext_lazy as _
 
 from promptfw.contrib.django.models import PromptTemplate
 

--- a/src/promptfw/contrib/django/management/commands/validate_prompts.py
+++ b/src/promptfw/contrib/django/management/commands/validate_prompts.py
@@ -93,13 +93,8 @@ class Command(BaseCommand):
         # 2. Required variables covered by defaults
         if tpl.variables_schema and tpl.is_active:
             for var_name, spec in tpl.variables_schema.items():
-                if (
-                    spec.get("required")
-                    and var_name not in (tpl.defaults or {})
-                ):
-                    self._warning(
-                        f"{prefix} Required variable '{var_name}' has no default"
-                    )
+                if spec.get("required") and var_name not in (tpl.defaults or {}):
+                    self._warning(f"{prefix} Required variable '{var_name}' has no default")
                     warnings += 1
 
         # 3. Jinja2 syntax
@@ -135,9 +130,7 @@ class Command(BaseCommand):
             .filter(cnt__gt=1)
         )
         for d in dupes:
-            self._error(
-                f"[{d['action_code']}] Duplicate active: {d['cnt']} active versions"
-            )
+            self._error(f"[{d['action_code']}] Duplicate active: {d['cnt']} active versions")
             errors += 1
         return errors
 

--- a/src/promptfw/contrib/django/migrations/0001_initial.py
+++ b/src/promptfw/contrib/django/migrations/0001_initial.py
@@ -13,7 +13,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []
@@ -88,9 +87,7 @@ class Migration(migrations.Migration):
                 (
                     "user_template",
                     models.TextField(
-                        help_text=(
-                            "User prompt (Jinja2). Variables: {{ var_name }}. Required."
-                        ),
+                        help_text=("User prompt (Jinja2). Variables: {{ var_name }}. Required."),
                         verbose_name="user template",
                     ),
                 ),

--- a/src/promptfw/contrib/django/models.py
+++ b/src/promptfw/contrib/django/models.py
@@ -37,6 +37,7 @@ except ImportError:
 
 # --- Enums ---
 
+
 class HubChoices(models.TextChoices):
     WRITING = "writing-hub", _("Writing Hub")
     TRAVEL_BEAT = "travel-beat", _("Travel Beat / DriftTales")
@@ -271,6 +272,4 @@ class PromptTemplate(models.Model):
         if self.variables_schema and self.defaults:
             unknown = set(self.defaults.keys()) - set(self.variables_schema.keys())
             if unknown:
-                raise ValidationError(
-                    {"defaults": f"Keys not in variables_schema: {unknown}"}
-                )
+                raise ValidationError({"defaults": f"Keys not in variables_schema: {unknown}"})

--- a/src/promptfw/contrib/django/resolution.py
+++ b/src/promptfw/contrib/django/resolution.py
@@ -144,9 +144,7 @@ def _load_from_db(action_code: str, *, tenant_id: int | None = None):
         deleted_at__isnull=True,
     )
     if _is_multi_tenant() and tenant_id is not None:
-        qs = qs.filter(
-            models.Q(tenant_id=tenant_id) | models.Q(tenant_id__isnull=True)
-        )
+        qs = qs.filter(models.Q(tenant_id=tenant_id) | models.Q(tenant_id__isnull=True))
     tpl = qs.order_by("-version").first()
 
     cache.set(cache_key, tpl if tpl else "__NONE__", timeout=_get_cache_ttl())
@@ -157,15 +155,11 @@ def _render_db_template(tpl, context: dict) -> list[dict[str, str]]:
     """Render DB template with SandboxedEnvironment."""
     messages = []
     if tpl.system_template:
-        sys_rendered = (
-            _JINJA_ENV.from_string(tpl.system_template).render(**context).strip()
-        )
+        sys_rendered = _JINJA_ENV.from_string(tpl.system_template).render(**context).strip()
         if sys_rendered:
             messages.append({"role": "system", "content": sys_rendered})
 
-    user_rendered = (
-        _JINJA_ENV.from_string(tpl.user_template).render(**context).strip()
-    )
+    user_rendered = _JINJA_ENV.from_string(tpl.user_template).render(**context).strip()
     messages.append({"role": "user", "content": user_rendered})
     return messages
 

--- a/src/promptfw/db_resolver.py
+++ b/src/promptfw/db_resolver.py
@@ -53,8 +53,7 @@ from promptfw.stack import PromptStack
 logger = logging.getLogger(__name__)
 
 _GENERIC_SYSTEM = (
-    "Du bist ein erfahrener Autor und Lektor. "
-    "Antworte praezise und kreativ auf Deutsch."
+    "Du bist ein erfahrener Autor und Lektor. Antworte praezise und kreativ auf Deutsch."
 )
 _GENERIC_USER = (
     "Erstelle die Planungsgrundlagen fuer folgendes Projekt:\n\n{context}\n\n"
@@ -111,7 +110,9 @@ class DBPromptResolver:
 
         logger.warning(
             "No DB config for slug=%r — using defaults (action_code=%s, prefix=%s)",
-            slug, self._default_action_code, self._default_template_prefix,
+            slug,
+            self._default_action_code,
+            self._default_template_prefix,
         )
         return {
             "action_code": self._default_action_code,
@@ -166,7 +167,8 @@ class DBPromptResolver:
         except Exception as exc:
             logger.warning(
                 "promptfw render failed for prefix=%r (%s) — using generic fallback",
-                prefix, exc,
+                prefix,
+                exc,
             )
 
         # 3. Generic fallback

--- a/src/promptfw/django_registry.py
+++ b/src/promptfw/django_registry.py
@@ -57,6 +57,7 @@ FieldMap = dict[str, str | Callable[[Any], Any]]
 # Built-in field maps
 # ---------------------------------------------------------------------------
 
+
 def _bfagent_output_format_to_response_format(obj: Any) -> str | None:
     """Map bfagent ``output_format`` choices to promptfw ``response_format``."""
     mapping = {
@@ -85,9 +86,7 @@ BFAGENT_FIELD_MAP: FieldMap = {
     # layer: always TASK for the primary record; SYSTEM split is handled separately
     "layer": lambda obj: TemplateLayer.TASK,
     # variables: union of required + optional
-    "variables": lambda obj: list(
-        (obj.required_variables or []) + (obj.optional_variables or [])
-    ),
+    "variables": lambda obj: list((obj.required_variables or []) + (obj.optional_variables or [])),
     # version: e.g. "1.0" → keep as-is
     "version": "version",
     # response_format: derived from output_format
@@ -110,6 +109,7 @@ BFAGENT_FIELD_MAP: FieldMap = {
 # ---------------------------------------------------------------------------
 # DjangoTemplateRegistry
 # ---------------------------------------------------------------------------
+
 
 class DjangoTemplateRegistry(TemplateRegistry):
     """
@@ -220,7 +220,7 @@ class DjangoTemplateRegistry(TemplateRegistry):
             except ValueError:
                 raise ValueError(
                     f"Invalid layer {layer!r} for id={template_id!r}. "
-                    f"Valid: {[l.value for l in TemplateLayer]}"
+                    f"Valid: {[member.value for member in TemplateLayer]}"
                 )
 
         # --- Validate response_format ---
@@ -238,9 +238,18 @@ class DjangoTemplateRegistry(TemplateRegistry):
             "template": task_template_text,
         }
         # Optional fields — only include if present in resolved and non-None
-        for field in ("variables", "version", "response_format", "output_schema",
-                      "phase", "task", "metadata", "cacheable", "tokens_estimate",
-                      "format_type"):
+        for field in (
+            "variables",
+            "version",
+            "response_format",
+            "output_schema",
+            "phase",
+            "task",
+            "metadata",
+            "cacheable",
+            "tokens_estimate",
+            "format_type",
+        ):
             val = resolved.get(field)
             if val is not None:
                 task_kwargs[field] = val
@@ -268,6 +277,7 @@ class DjangoTemplateRegistry(TemplateRegistry):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _resolve_fields(obj: Any, field_map: FieldMap) -> dict[str, Any]:
     """Resolve all entries in a field_map against an ORM object."""

--- a/src/promptfw/frontmatter.py
+++ b/src/promptfw/frontmatter.py
@@ -25,6 +25,7 @@ Usage::
     # [{"role": "system", "content": "Du bist ein Experte."},
     #  {"role": "user", "content": "Analysiere: Lorem ipsum"}]
 """
+
 from __future__ import annotations
 
 import logging
@@ -79,16 +80,14 @@ def render_frontmatter_string(
         import yaml
     except ImportError as e:
         raise ImportError(
-            "PyYAML is required for frontmatter templates. "
-            "Install with: pip install pyyaml"
+            "PyYAML is required for frontmatter templates. Install with: pip install pyyaml"
         ) from e
 
     try:
         from jinja2 import Template
     except ImportError as e:
         raise ImportError(
-            "Jinja2 is required for frontmatter templates. "
-            "Install with: pip install jinja2"
+            "Jinja2 is required for frontmatter templates. Install with: pip install jinja2"
         ) from e
 
     if not content.startswith("---"):
@@ -100,9 +99,7 @@ def render_frontmatter_string(
 
     frontmatter = yaml.safe_load(parts[1])
     if not isinstance(frontmatter, dict):
-        raise ValueError(
-            f"Frontmatter must be a YAML dict, got {type(frontmatter).__name__}"
-        )
+        raise ValueError(f"Frontmatter must be a YAML dict, got {type(frontmatter).__name__}")
 
     messages: list[dict[str, str]] = []
 

--- a/src/promptfw/lektorat.py
+++ b/src/promptfw/lektorat.py
@@ -82,7 +82,7 @@ LEKTORAT_TEMPLATES: list[PromptTemplate] = [
             "{% if chapter_number %}Kapitel: {{ chapter_number }}\n{% endif %}"
             "TEXT:\n{{ content }}\n\n"
             "Antworte NUR als JSON-Array: "
-            "[{\"name\": \"...\", \"varianten\": [], \"rolle\": \"...\", ...}]"
+            '[{"name": "...", "varianten": [], "rolle": "...", ...}]'
         ),
         variables=["content", "chapter_number"],
     ),
@@ -101,10 +101,10 @@ LEKTORAT_TEMPLATES: list[PromptTemplate] = [
             "- Namensvarianten die nicht dokumentiert sind\n"
             "- Verhaltensinkonsistenzen gegenüber etabliertem Charakter\n\n"
             "Antworte NUR als JSON:\n"
-            "{\"inconsistencies\": [{\"figur\": \"...\", \"typ\": \"...\", "
-            "\"kapitel_alt\": 0, \"kapitel_neu\": 0, "
-            "\"wert_alt\": \"...\", \"wert_neu\": \"...\", "
-            "\"schwere\": \"hoch/mittel/niedrig\"}]}"
+            '{"inconsistencies": [{"figur": "...", "typ": "...", '
+            '"kapitel_alt": 0, "kapitel_neu": 0, '
+            '"wert_alt": "...", "wert_neu": "...", '
+            '"schwere": "hoch/mittel/niedrig"}]}'
         ),
         variables=["known_characters", "chapter_number", "new_references"],
     ),
@@ -127,11 +127,11 @@ LEKTORAT_TEMPLATES: list[PromptTemplate] = [
             "- Typische Sprachmuster und Stilmittel\n\n"
             "TEXT:\n{{ text }}\n\n"
             "Antworte NUR als JSON:\n"
-            "{\"satzstruktur\": \"...\", \"wortwahl\": \"...\", "
-            "\"perspektive\": \"...\", \"dialog\": \"...\", "
-            "\"beschreibung\": \"...\", \"emotionale_tiefe\": \"...\", "
-            "\"typische_muster\": [], \"stilmittel\": [], "
-            "\"gesamteindruck\": \"...\"}"
+            '{"satzstruktur": "...", "wortwahl": "...", '
+            '"perspektive": "...", "dialog": "...", '
+            '"beschreibung": "...", "emotionale_tiefe": "...", '
+            '"typische_muster": [], "stilmittel": [], '
+            '"gesamteindruck": "..."}'
         ),
         variables=["text"],
     ),
@@ -151,10 +151,10 @@ LEKTORAT_TEMPLATES: list[PromptTemplate] = [
             "{% if threshold %}Melde nur Wiederholungen ab {{ threshold }}× Vorkommen.\n{% endif %}"
             "TEXT:\n{{ text }}\n\n"
             "Antworte NUR als JSON:\n"
-            "{\"wort_wiederholungen\": [{\"wort\": \"...\", \"anzahl\": 0, "
-            "\"positionen\": []}], "
-            "\"phrasen_wiederholungen\": [{\"phrase\": \"...\", \"anzahl\": 0}], "
-            "\"inhaltliche_wiederholungen\": [\"...\"]}"
+            '{"wort_wiederholungen": [{"wort": "...", "anzahl": 0, '
+            '"positionen": []}], '
+            '"phrasen_wiederholungen": [{"phrase": "...", "anzahl": 0}], '
+            '"inhaltliche_wiederholungen": ["..."]}'
         ),
         variables=["text", "threshold"],
     ),
@@ -175,10 +175,10 @@ LEKTORAT_TEMPLATES: list[PromptTemplate] = [
             "- Inkonsistenten Zeitangaben (Tageszeit, Datum, Jahreszeit)\n"
             "- Flashbacks die nicht klar markiert sind\n\n"
             "Antworte NUR als JSON:\n"
-            "{\"ereignisse\": [{\"beschreibung\": \"...\", \"zeitpunkt\": \"...\"}], "
-            "\"widersprueche\": [{\"ereignis_a\": \"...\", \"ereignis_b\": \"...\", "
-            "\"problem\": \"...\"}], "
-            "\"unklarheiten\": [\"...\"]}"
+            '{"ereignisse": [{"beschreibung": "...", "zeitpunkt": "..."}], '
+            '"widersprueche": [{"ereignis_a": "...", "ereignis_b": "...", '
+            '"problem": "..."}], '
+            '"unklarheiten": ["..."]}'
         ),
         variables=["text", "known_events"],
     ),

--- a/src/promptfw/parsing.py
+++ b/src/promptfw/parsing.py
@@ -211,13 +211,9 @@ def extract_field(
         if name.lower() != target:
             continue
 
-        # Continuation: text between end of this header and start of next header.
+        # Continuation: text between end of this header and start of the next header.
         if idx + 1 < len(entries):
-            next_header_end = entries[idx + 1][0]
-            # next header's m.start() = next_header_end minus the header length;
-            # use m.start() stored separately for clean slicing.
-            # Re-find next header start by scanning back from next_header_end.
-            continuation_text = text[header_end:_header_start(entries, idx + 1, text)]
+            continuation_text = text[header_end : _header_start(entries, idx + 1, text)]
         else:
             continuation_text = text[header_end:]
 

--- a/src/promptfw/planning.py
+++ b/src/promptfw/planning.py
@@ -41,7 +41,7 @@ PLANNING_TEMPLATES: list[PromptTemplate] = [
             "1. Prämisse (2-3 Sätze): Die zentrale Idee und das Herz der Geschichte.\n"
             "2. Drei zentrale Themen (als Liste).\n"
             "3. Logline (1 Satz): Protagonist + Ziel + Hindernis + Einsatz.\n\n"
-            "Antworte als JSON: {\"premise\": \"...\", \"themes\": [\"...\"], \"logline\": \"...\"}"
+            'Antworte als JSON: {"premise": "...", "themes": ["..."], "logline": "..."}'
         ),
         variables=["title", "genre", "description"],
     ),
@@ -77,8 +77,8 @@ PLANNING_TEMPLATES: list[PromptTemplate] = [
             "2. Drei Hauptthemen (als Liste).\n"
             "3. Kurzzusammenfassung (Abstract, 100 Wörter): Für wen ist das Buch und was lernen Leser?\n"
             "4. Primäre Zielgruppe (1 Satz).\n\n"
-            "Antworte als JSON: {\"core_message\": \"...\", \"themes\": [\"...\"], "
-            "\"abstract\": \"...\", \"target_audience\": \"...\"}"
+            'Antworte als JSON: {"core_message": "...", "themes": ["..."], '
+            '"abstract": "...", "target_audience": "..."}'
         ),
         variables=["title", "description"],
     ),
@@ -116,8 +116,8 @@ PLANNING_TEMPLATES: list[PromptTemplate] = [
             "2. Zielsetzung (2-3 Sätze): Was soll die Arbeit zeigen/beweisen/entwickeln?\n"
             "3. Abstract (ca. 150 Wörter): Fragestellung, Methode, erwartete Ergebnisse, Relevanz.\n"
             "4. Fünf wissenschaftliche Keywords.\n\n"
-            "Antworte als JSON: {\"research_question\": \"...\", \"objective\": \"...\", "
-            "\"abstract\": \"...\", \"keywords\": [\"...\"]}"
+            'Antworte als JSON: {"research_question": "...", "objective": "...", '
+            '"abstract": "...", "keywords": ["..."]}'
         ),
         variables=["title", "field_of_study", "description"],
     ),
@@ -157,8 +157,8 @@ PLANNING_TEMPLATES: list[PromptTemplate] = [
             "3. Nullhypothese (H0, 1 Satz).\n"
             "4. Abstract (IMRaD, ca. 200 Wörter): Introduction / Methods / Results / Discussion.\n"
             "5. Fünf Keywords für die Literaturdatenbank.\n\n"
-            "Antworte als JSON: {\"research_question\": \"...\", \"hypothesis\": \"...\", "
-            "\"null_hypothesis\": \"...\", \"abstract\": \"...\", \"keywords\": [\"...\"]}"
+            'Antworte als JSON: {"research_question": "...", "hypothesis": "...", '
+            '"null_hypothesis": "...", "abstract": "...", "keywords": ["..."]}'
         ),
         variables=["title", "field_of_study", "description"],
     ),
@@ -195,8 +195,8 @@ PLANNING_TEMPLATES: list[PromptTemplate] = [
             "2. Drei Hauptargumente (als Liste), die die These stützen.\n"
             "3. Gegenargument (1 Satz): Stärkster Einwand gegen die These.\n"
             "4. Schlussrichtung (1 Satz): Wie wird der Essay enden/auflösen?\n\n"
-            "Antworte als JSON: {\"thesis\": \"...\", \"main_arguments\": [\"...\"], "
-            "\"counter_argument\": \"...\", \"conclusion_direction\": \"...\"}"
+            'Antworte als JSON: {"thesis": "...", "main_arguments": ["..."], '
+            '"counter_argument": "...", "conclusion_direction": "..."}'
         ),
         variables=["title", "description"],
     ),

--- a/src/promptfw/registry.py
+++ b/src/promptfw/registry.py
@@ -66,6 +66,7 @@ class TemplateRegistry:
         strict = getattr(self, "_strict", False)
         if yaml is None:
             import yaml as _yaml
+
             yaml = _yaml
         try:
             with open(yaml_file) as f:
@@ -192,6 +193,7 @@ class TemplateRegistry:
             logger.warning("reload() called but no templates_dir set")
             return
         import yaml
+
         self._templates.clear()
         for yaml_file in self._templates_dir.rglob("*.yaml"):
             self._load_yaml_file(yaml_file, yaml)

--- a/src/promptfw/renderer.py
+++ b/src/promptfw/renderer.py
@@ -92,13 +92,14 @@ class PromptRenderer:
         # FEW_SHOT always appended last regardless of registration order.
         _system_layers = (TemplateLayer.SYSTEM, TemplateLayer.FORMAT)
         _few_shot = TemplateLayer.FEW_SHOT
+        # Canonical render order: system block → user-context sub-layers (in
+        # USER_LAYERS order: CONTEXT → PROJECT → CHAPTER → SCENE → TASK) → few-shot.
+        # The full per-layer index is required — bucketing all USER_LAYERS to one
+        # key would leave the context sub-layers in registration order (stable sort).
+        _canonical_order = (*_system_layers, *USER_LAYERS, _few_shot)
         ordered = sorted(
             templates,
-            key=lambda t: (
-                0 if t.layer in _system_layers else
-                1 if t.layer in USER_LAYERS else
-                2  # FEW_SHOT
-            ),
+            key=lambda t: _canonical_order.index(t.layer),
         )
 
         for tmpl in ordered:
@@ -109,9 +110,7 @@ class PromptRenderer:
                     if user_text:
                         few_shot_messages.append({"role": "user", "content": user_text})
                     if assistant_text:
-                        few_shot_messages.append(
-                            {"role": "assistant", "content": assistant_text}
-                        )
+                        few_shot_messages.append({"role": "assistant", "content": assistant_text})
                 continue
 
             rendered = self.render_template(tmpl, context)
@@ -182,6 +181,7 @@ class PromptRenderer:
         """Rough token estimate — 1 token ≈ 4 chars. Use tiktoken for accuracy."""
         try:
             import tiktoken
+
             enc = tiktoken.get_encoding("cl100k_base")
             return len(enc.encode(text))
         except ImportError:

--- a/src/promptfw/schema.py
+++ b/src/promptfw/schema.py
@@ -11,6 +11,7 @@ def _auto_token_count(text: str) -> int:
     """Return tiktoken token count if available, else 0 (no estimate)."""
     try:
         import tiktoken
+
         enc = tiktoken.get_encoding("cl100k_base")
         return len(enc.encode(text))
     except ImportError:

--- a/src/promptfw/stack.py
+++ b/src/promptfw/stack.py
@@ -86,9 +86,7 @@ class PromptStack:
         template = self.registry.get(pattern)
         return self.renderer.render_stack([template], context)
 
-    def render_stack(
-        self, patterns: list[str], context: dict[str, Any]
-    ) -> RenderedPrompt:
+    def render_stack(self, patterns: list[str], context: dict[str, Any]) -> RenderedPrompt:
         """
         Render multiple templates (in order) into a combined RenderedPrompt.
 

--- a/src/promptfw/writing.py
+++ b/src/promptfw/writing.py
@@ -136,7 +136,7 @@ WRITING_TEMPLATES: list[PromptTemplate] = [
         format_type="roman",
         phase="writing",
         template=(
-            "Schreibe Kapitel {{ chapter_number }}: \"{{ chapter_title }}\"\n\n"
+            'Schreibe Kapitel {{ chapter_number }}: "{{ chapter_title }}"\n\n'
             "{% if story_premise %}Prämisse: {{ story_premise }}\n{% endif %}"
             "{% if prior_chapter_summary %}Zusammenfassung des vorherigen Kapitels:\n{{ prior_chapter_summary }}\n\n{% endif %}"
             "Outline dieses Kapitels:\n{{ chapter_outline }}\n\n"

--- a/tests/test_contrib_django.py
+++ b/tests/test_contrib_django.py
@@ -40,7 +40,6 @@ import pytest
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection
-from django.test.utils import setup_test_environment
 
 from promptfw.contrib.django.models import (
     HAS_PYDANTIC,
@@ -273,9 +272,7 @@ class TestResolution:
 
     def test_render_prompt_from_db(self, sample_template):
         """T19: render_prompt() resolves from DB and renders correctly."""
-        messages = render_prompt(
-            "test-hub.domain.action", role="assistant", topic="Python"
-        )
+        messages = render_prompt("test-hub.domain.action", role="assistant", topic="Python")
         assert len(messages) == 2
         assert messages[0]["role"] == "system"
         assert "assistant" in messages[0]["content"]
@@ -284,9 +281,7 @@ class TestResolution:
 
     def test_render_prompt_uses_defaults(self, sample_template):
         """T20: render_prompt() merges defaults — caller wins on conflict."""
-        messages = render_prompt(
-            "test-hub.domain.action", topic="AI"
-        )
+        messages = render_prompt("test-hub.domain.action", topic="AI")
         # role comes from defaults ("writer")
         assert "writer" in messages[0]["content"]
         assert "AI" in messages[1]["content"]
@@ -353,9 +348,7 @@ class TestResolution:
 
     def test_render_db_template_sandboxed(self, sample_template):
         """T29: _render_db_template uses SandboxedEnvironment (no introspection)."""
-        messages = _render_db_template(
-            sample_template, {"role": "test", "topic": "safety"}
-        )
+        messages = _render_db_template(sample_template, {"role": "test", "topic": "safety"})
         assert len(messages) == 2
         assert "test" in messages[0]["content"]
 
@@ -454,9 +447,7 @@ class TestAdmin:
         old = PromptTemplate.objects.get(pk=sample_template.pk)
         assert old.is_active is False
 
-        new = PromptTemplate.objects.get(
-            action_code="test-hub.domain.action", version=2
-        )
+        new = PromptTemplate.objects.get(action_code="test-hub.domain.action", version=2)
         assert new.is_active is True
         assert new.created_by == "testuser"
 

--- a/tests/test_django_registry.py
+++ b/tests/test_django_registry.py
@@ -8,23 +8,22 @@ objects, ensuring the registry can be tested without a Django environment.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
 
 import pytest
 
 from promptfw.django_registry import (
-    BFAGENT_FIELD_MAP,
     DjangoTemplateRegistry,
     _bfagent_output_format_to_response_format,
     _safe_repr,
 )
 from promptfw.exceptions import TemplateNotFoundError
-from promptfw.schema import PromptTemplate, TemplateLayer
+from promptfw.schema import TemplateLayer
 
 
 # ---------------------------------------------------------------------------
 # Helpers — build mock ORM objects
 # ---------------------------------------------------------------------------
+
 
 def _make_bfagent_obj(**kwargs) -> SimpleNamespace:
     """Return a SimpleNamespace mimicking a bfagent PromptTemplate ORM object."""
@@ -54,6 +53,7 @@ def _make_bfagent_obj(**kwargs) -> SimpleNamespace:
 # ---------------------------------------------------------------------------
 # from_queryset — basic happy path
 # ---------------------------------------------------------------------------
+
 
 class TestFromQueryset:
     def test_should_load_task_template_from_single_object(self):
@@ -120,6 +120,7 @@ class TestFromQueryset:
 # Field mapping
 # ---------------------------------------------------------------------------
 
+
 class TestFieldMapping:
     def test_should_combine_required_and_optional_variables(self):
         obj = _make_bfagent_obj(
@@ -179,6 +180,7 @@ class TestFieldMapping:
 # output_format → response_format mapping
 # ---------------------------------------------------------------------------
 
+
 class TestOutputFormatMapping:
     def test_should_map_json_to_json_object(self):
         obj = _make_bfagent_obj(output_format="json")
@@ -219,6 +221,7 @@ class TestOutputFormatMapping:
 # strict mode
 # ---------------------------------------------------------------------------
 
+
 class TestStrictMode:
     def test_should_raise_on_empty_template_key_in_strict_mode(self):
         obj = _make_bfagent_obj(template_key="")
@@ -244,6 +247,7 @@ class TestStrictMode:
 # ---------------------------------------------------------------------------
 # Custom field_map
 # ---------------------------------------------------------------------------
+
 
 class TestCustomFieldMap:
     def test_should_accept_custom_field_map(self):
@@ -276,6 +280,7 @@ class TestCustomFieldMap:
 # ---------------------------------------------------------------------------
 # Integration: rendering with PromptRenderer
 # ---------------------------------------------------------------------------
+
 
 class TestIntegrationWithRenderer:
     def test_should_render_task_template_from_registry(self):
@@ -325,6 +330,7 @@ class TestIntegrationWithRenderer:
 # _safe_repr
 # ---------------------------------------------------------------------------
 
+
 class TestSafeRepr:
     def test_should_include_class_name(self):
         obj = _make_bfagent_obj()
@@ -341,5 +347,6 @@ class TestSafeRepr:
             @property
             def pk(self):
                 raise RuntimeError("broken")
+
         r = _safe_repr(Broken())
         assert r  # just doesn't crash

--- a/tests/test_for_format.py
+++ b/tests/test_for_format.py
@@ -13,9 +13,7 @@ def _tmpl(
     text: str = "hello",
     fmt: str | None = None,
 ) -> PromptTemplate:
-    return PromptTemplate(
-        id=tid, layer=layer, template=text, format_type=fmt, tokens_estimate=0
-    )
+    return PromptTemplate(id=tid, layer=layer, template=text, format_type=fmt, tokens_estimate=0)
 
 
 class TestForFormat:

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,6 +1,6 @@
 """Tests for promptfw.frontmatter module."""
+
 import pytest
-from pathlib import Path
 
 from promptfw.frontmatter import render_frontmatter_file, render_frontmatter_string
 
@@ -83,9 +83,7 @@ user: |
   {% if chapter_text %}Kapitel: {{ chapter_text }}{% endif %}
   {% if focus %}Fokus: {{ focus }}{% endif %}
 ---"""
-        messages = render_frontmatter_string(
-            content, chapter_text="Einleitung", focus="Methodik"
-        )
+        messages = render_frontmatter_string(content, chapter_text="Einleitung", focus="Methodik")
         assert "Einleitung" in messages[1]["content"]
         assert "Methodik" in messages[1]["content"]
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -19,6 +19,7 @@ from promptfw.stack import PromptStack
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _tmpl(tid: str, layer: TemplateLayer, text: str = "hello") -> PromptTemplate:
     return PromptTemplate(id=tid, layer=layer, template=text, tokens_estimate=0)
 
@@ -27,28 +28,33 @@ def _tmpl(tid: str, layer: TemplateLayer, text: str = "hello") -> PromptTemplate
 # Issue #7 — TemplateRegistry.get_or_fallback()
 # ---------------------------------------------------------------------------
 
+
 class TestGetOrFallback:
     def test_should_return_first_match(self):
         reg = TemplateRegistry()
         reg.register(_tmpl("writing.task.write_chapter", TemplateLayer.TASK))
         reg.register(_tmpl("writing.task.default", TemplateLayer.TASK))
 
-        t = reg.get_or_fallback([
-            "writing.task.write_chapter.roman",
-            "writing.task.write_chapter",
-            "writing.task.default",
-        ])
+        t = reg.get_or_fallback(
+            [
+                "writing.task.write_chapter.roman",
+                "writing.task.write_chapter",
+                "writing.task.default",
+            ]
+        )
         assert t.id == "writing.task.write_chapter"
 
     def test_should_skip_missing_and_use_fallback(self):
         reg = TemplateRegistry()
         reg.register(_tmpl("writing.task.default", TemplateLayer.TASK))
 
-        t = reg.get_or_fallback([
-            "writing.task.write_chapter.roman",
-            "writing.task.write_chapter",
-            "writing.task.default",
-        ])
+        t = reg.get_or_fallback(
+            [
+                "writing.task.write_chapter.roman",
+                "writing.task.write_chapter",
+                "writing.task.default",
+            ]
+        )
         assert t.id == "writing.task.default"
 
     def test_should_raise_when_all_missing(self):
@@ -73,6 +79,7 @@ class TestGetOrFallback:
 # Issue #9 — tokens_estimate auto-calculation
 # ---------------------------------------------------------------------------
 
+
 class TestTokensEstimate:
     def test_should_auto_calculate_when_zero_and_tiktoken_available(self):
         tmpl = PromptTemplate(
@@ -83,6 +90,7 @@ class TestTokensEstimate:
         )
         try:
             import tiktoken  # noqa: F401
+
             assert tmpl.tokens_estimate > 0
         except ImportError:
             assert tmpl.tokens_estimate == 0
@@ -109,6 +117,7 @@ class TestTokensEstimate:
 # ---------------------------------------------------------------------------
 # Issue #3 — PromptStack.render_with_fallback()
 # ---------------------------------------------------------------------------
+
 
 class TestRenderWithFallback:
     def test_should_use_first_matching_fallback(self):
@@ -141,6 +150,7 @@ class TestRenderWithFallback:
 # ---------------------------------------------------------------------------
 # Issue #2 — context_scope sub-layers
 # ---------------------------------------------------------------------------
+
 
 class TestContextSubLayers:
     def test_should_have_new_sub_layers_in_enum(self):

--- a/tests/test_lektorat.py
+++ b/tests/test_lektorat.py
@@ -1,7 +1,5 @@
 """Tests for promptfw lektorat templates and get_lektorat_stack."""
 
-import pytest
-
 from promptfw.schema import TemplateLayer
 from promptfw.stack import PromptStack
 from promptfw.lektorat import LEKTORAT_TEMPLATES, get_lektorat_stack
@@ -74,56 +72,77 @@ class TestGetLektoratStack:
 
     def test_should_render_extract_characters_task(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.extract_characters", {
-            "content": "Elias betrat die Schmiede. Maria wartete bereits auf ihn.",
-        })
+        rendered = stack.render(
+            "lektorat.task.extract_characters",
+            {
+                "content": "Elias betrat die Schmiede. Maria wartete bereits auf ihn.",
+            },
+        )
         assert "Elias" in rendered.user
         assert "JSON-Array" in rendered.user
 
     def test_should_render_extract_characters_with_optional_chapter_number(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.extract_characters", {
-            "content": "Elias betrat die Schmiede.",
-            "chapter_number": 3,
-        })
+        rendered = stack.render(
+            "lektorat.task.extract_characters",
+            {
+                "content": "Elias betrat die Schmiede.",
+                "chapter_number": 3,
+            },
+        )
         assert "3" in rendered.user
 
     def test_should_render_analyze_style_task(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.analyze_style", {
-            "text": "Er ging langsam durch die Gassen. Die Stille drückte auf ihn ein.",
-        })
+        rendered = stack.render(
+            "lektorat.task.analyze_style",
+            {
+                "text": "Er ging langsam durch die Gassen. Die Stille drückte auf ihn ein.",
+            },
+        )
         assert "Er ging langsam" in rendered.user
         assert "JSON" in rendered.user
 
     def test_should_render_find_repetitions_task(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.find_repetitions", {
-            "text": "Er lief. Er lief schnell. Er lief immer schneller.",
-        })
+        rendered = stack.render(
+            "lektorat.task.find_repetitions",
+            {
+                "text": "Er lief. Er lief schnell. Er lief immer schneller.",
+            },
+        )
         assert "Er lief" in rendered.user
 
     def test_should_render_find_repetitions_with_threshold(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.find_repetitions", {
-            "text": "Testtext.",
-            "threshold": 3,
-        })
+        rendered = stack.render(
+            "lektorat.task.find_repetitions",
+            {
+                "text": "Testtext.",
+                "threshold": 3,
+            },
+        )
         assert "3" in rendered.user
 
     def test_should_render_check_timeline_task(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.check_timeline", {
-            "text": "Am Montag passierte X. Am Dienstag war schon Y passiert.",
-        })
+        rendered = stack.render(
+            "lektorat.task.check_timeline",
+            {
+                "text": "Am Montag passierte X. Am Dienstag war schon Y passiert.",
+            },
+        )
         assert "Montag" in rendered.user
 
     def test_should_render_check_timeline_with_optional_known_events(self):
         stack = get_lektorat_stack()
-        rendered = stack.render("lektorat.task.check_timeline", {
-            "text": "Am Montag passierte X.",
-            "known_events": "Tag 1: Ankunft. Tag 2: Konflikt.",
-        })
+        rendered = stack.render(
+            "lektorat.task.check_timeline",
+            {
+                "text": "Am Montag passierte X.",
+                "known_events": "Tag 1: Ankunft. Tag 2: Konflikt.",
+            },
+        )
         assert "Ankunft" in rendered.user
 
     def test_should_render_system_analyst_into_system_prompt(self):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -47,7 +47,7 @@ class TestExtractJson:
         assert result == {"fenced": True}
 
     def test_should_handle_case_insensitive_json_fence(self):
-        text = "```JSON\n{\"key\": \"val\"}\n```"
+        text = '```JSON\n{"key": "val"}\n```'
         result = extract_json(text)
         assert result == {"key": "val"}
 

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,6 +1,5 @@
 """Tests for promptfw planning templates and get_planning_stack."""
 
-import pytest
 from promptfw.planning import get_planning_stack, PLANNING_TEMPLATES
 from promptfw.schema import TemplateLayer
 
@@ -8,9 +7,7 @@ from promptfw.schema import TemplateLayer
 class TestPlanningTemplates:
     def test_all_formats_have_task_template(self):
         formats = {"roman", "nonfiction", "academic", "scientific", "essay"}
-        task_formats = {
-            t.format_type for t in PLANNING_TEMPLATES if t.layer == TemplateLayer.TASK
-        }
+        task_formats = {t.format_type for t in PLANNING_TEMPLATES if t.layer == TemplateLayer.TASK}
         assert formats == task_formats
 
     def test_all_formats_have_system_template(self):
@@ -53,6 +50,7 @@ class TestPlanningTemplates:
 class TestGetPlanningStack:
     def test_returns_promptstack(self):
         from promptfw.stack import PromptStack
+
         stack = get_planning_stack()
         assert isinstance(stack, PromptStack)
 
@@ -64,11 +62,14 @@ class TestGetPlanningStack:
 
     def test_render_roman_planning(self):
         stack = get_planning_stack()
-        rendered = stack.render("roman.task.planning", {
-            "title": "Der letzte Magier",
-            "genre": "Fantasy",
-            "description": "Ein junger Schmied entdeckt seine magischen Kräfte.",
-        })
+        rendered = stack.render(
+            "roman.task.planning",
+            {
+                "title": "Der letzte Magier",
+                "genre": "Fantasy",
+                "description": "Ein junger Schmied entdeckt seine magischen Kräfte.",
+            },
+        )
         assert "Der letzte Magier" in rendered.user
         assert "Fantasy" in rendered.user
 
@@ -87,41 +88,53 @@ class TestGetPlanningStack:
 
     def test_render_academic_planning(self):
         stack = get_planning_stack()
-        rendered = stack.render("academic.task.planning", {
-            "title": "KI in der Medizin",
-            "field_of_study": "Medizininformatik",
-            "description": "Auswirkungen von LLMs auf die Diagnosestellung.",
-            "citation_style": "APA",
-        })
+        rendered = stack.render(
+            "academic.task.planning",
+            {
+                "title": "KI in der Medizin",
+                "field_of_study": "Medizininformatik",
+                "description": "Auswirkungen von LLMs auf die Diagnosestellung.",
+                "citation_style": "APA",
+            },
+        )
         assert "KI in der Medizin" in rendered.user
         assert "Medizininformatik" in rendered.user
         assert "APA" in rendered.user
 
     def test_render_scientific_planning(self):
         stack = get_planning_stack()
-        rendered = stack.render("scientific.task.planning", {
-            "title": "Wirksamkeit von X",
-            "field_of_study": "Pharmakologie",
-            "description": "Klinische Studie zur Wirksamkeit.",
-            "citation_style": "Vancouver",
-        })
+        rendered = stack.render(
+            "scientific.task.planning",
+            {
+                "title": "Wirksamkeit von X",
+                "field_of_study": "Pharmakologie",
+                "description": "Klinische Studie zur Wirksamkeit.",
+                "citation_style": "Vancouver",
+            },
+        )
         assert "Wirksamkeit von X" in rendered.user
 
     def test_render_essay_planning(self):
         stack = get_planning_stack()
-        rendered = stack.render("essay.task.planning", {
-            "title": "Über die Grenzen der KI",
-            "description": "Ein Essay über ethische Grenzen.",
-        })
+        rendered = stack.render(
+            "essay.task.planning",
+            {
+                "title": "Über die Grenzen der KI",
+                "description": "Ein Essay über ethische Grenzen.",
+            },
+        )
         assert "Über die Grenzen der KI" in rendered.user
 
     def test_render_nonfiction_planning(self):
         stack = get_planning_stack()
-        rendered = stack.render("nonfiction.task.planning", {
-            "title": "Produktivität ohne Burnout",
-            "description": "Praktische Strategien für nachhaltige Leistung.",
-            "field_of_study": "Psychologie",
-        })
+        rendered = stack.render(
+            "nonfiction.task.planning",
+            {
+                "title": "Produktivität ohne Burnout",
+                "description": "Praktische Strategien für nachhaltige Leistung.",
+                "field_of_study": "Psychologie",
+            },
+        )
         assert "Produktivität ohne Burnout" in rendered.user
 
     def test_multiple_stacks_are_independent(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -10,9 +10,15 @@ from promptfw.schema import PromptTemplate, TemplateLayer
 @pytest.fixture
 def registry():
     r = TemplateRegistry()
-    r.register(PromptTemplate(id="roman.draft.scene", layer=TemplateLayer.TASK, template="Write scene"))
-    r.register(PromptTemplate(id="roman.draft.outline", layer=TemplateLayer.TASK, template="Write outline"))
-    r.register(PromptTemplate(id="system.base", layer=TemplateLayer.SYSTEM, template="You are an AI"))
+    r.register(
+        PromptTemplate(id="roman.draft.scene", layer=TemplateLayer.TASK, template="Write scene")
+    )
+    r.register(
+        PromptTemplate(id="roman.draft.outline", layer=TemplateLayer.TASK, template="Write outline")
+    )
+    r.register(
+        PromptTemplate(id="system.base", layer=TemplateLayer.SYSTEM, template="You are an AI")
+    )
     return r
 
 
@@ -40,7 +46,9 @@ def test_should_list_templates_filtered_by_layer(registry):
 
 
 def test_should_overwrite_template_with_same_id(registry):
-    registry.register(PromptTemplate(id="system.base", layer=TemplateLayer.SYSTEM, template="Updated"))
+    registry.register(
+        PromptTemplate(id="system.base", layer=TemplateLayer.SYSTEM, template="Updated")
+    )
     assert registry.get("system.base").template == "Updated"
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -32,7 +32,9 @@ def test_should_combine_system_and_format_into_system_user_into_user(renderer):
         PromptTemplate(id="f1", layer=TemplateLayer.FORMAT, template="Use {{ style }} style."),
         PromptTemplate(id="t1", layer=TemplateLayer.TASK, template="Write about {{ topic }}."),
     ]
-    result = renderer.render_stack(templates, {"role": "author", "style": "formal", "topic": "dragons"})
+    result = renderer.render_stack(
+        templates, {"role": "author", "style": "formal", "topic": "dragons"}
+    )
     assert "author" in result.system
     assert "formal" in result.system
     assert "dragons" in result.user
@@ -57,8 +59,9 @@ def test_should_skip_whitespace_only_templates(renderer):
 
 
 def test_should_estimate_nonzero_tokens_for_nonempty_template(renderer):
-    t = PromptTemplate(id="t1", layer=TemplateLayer.TASK,
-                       template="Write a long story about dragons and wizards.")
+    t = PromptTemplate(
+        id="t1", layer=TemplateLayer.TASK, template="Write a long story about dragons and wizards."
+    )
     result = renderer.render_stack([t], {})
     assert result.estimated_tokens > 0
 

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -10,7 +10,7 @@ Befund #10: output_schema/response_format nur von TASK-Layer propagiert
 import pytest
 
 from promptfw.exceptions import LLMResponseError, TemplateRenderError
-from promptfw.schema import VALID_RESPONSE_FORMATS, PromptTemplate, RenderedPrompt, TemplateLayer
+from promptfw.schema import VALID_RESPONSE_FORMATS, PromptTemplate, TemplateLayer
 from promptfw.registry import TemplateRegistry
 from promptfw.renderer import PromptRenderer
 
@@ -18,6 +18,7 @@ from promptfw.renderer import PromptRenderer
 # ---------------------------------------------------------------------------
 # Befund #9 — LLMResponseError ist separater Exception-Typ
 # ---------------------------------------------------------------------------
+
 
 class TestLLMResponseError:
     def test_should_not_be_instance_of_template_render_error(self):
@@ -34,6 +35,7 @@ class TestLLMResponseError:
 
     def test_should_not_be_caught_by_template_render_error_handler(self):
         from promptfw.parsing import extract_json_strict
+
         caught_as_render_error = False
         caught_as_llm_error = False
         try:
@@ -50,6 +52,7 @@ class TestLLMResponseError:
 # Befund #10 — output_schema/response_format nur von TASK-Layer propagiert
 # ---------------------------------------------------------------------------
 
+
 class TestResponseFormatPropagation:
     def _make_renderer(self):
         return PromptRenderer()
@@ -58,11 +61,14 @@ class TestResponseFormatPropagation:
         renderer = self._make_renderer()
         templates = [
             PromptTemplate(
-                id="t.system.base", layer=TemplateLayer.SYSTEM,
-                template="You are an analyst.", cacheable=True,
+                id="t.system.base",
+                layer=TemplateLayer.SYSTEM,
+                template="You are an analyst.",
+                cacheable=True,
             ),
             PromptTemplate(
-                id="t.task.extract", layer=TemplateLayer.TASK,
+                id="t.task.extract",
+                layer=TemplateLayer.TASK,
                 template="Extract data from: {{ text }}",
                 variables=["text"],
                 response_format="json_object",
@@ -75,13 +81,15 @@ class TestResponseFormatPropagation:
         renderer = self._make_renderer()
         templates = [
             PromptTemplate(
-                id="t.system.base", layer=TemplateLayer.SYSTEM,
+                id="t.system.base",
+                layer=TemplateLayer.SYSTEM,
                 template="You are an analyst.",
                 cacheable=True,
                 response_format="json_object",  # should be ignored
             ),
             PromptTemplate(
-                id="t.task.plain", layer=TemplateLayer.TASK,
+                id="t.task.plain",
+                layer=TemplateLayer.TASK,
                 template="Do something.",
                 # no response_format
             ),
@@ -93,13 +101,15 @@ class TestResponseFormatPropagation:
         renderer = self._make_renderer()
         templates = [
             PromptTemplate(
-                id="t.format.roman", layer=TemplateLayer.FORMAT,
+                id="t.format.roman",
+                layer=TemplateLayer.FORMAT,
                 template="Format rules.",
                 cacheable=True,
                 response_format="json_schema",  # should be ignored
             ),
             PromptTemplate(
-                id="t.task.write", layer=TemplateLayer.TASK,
+                id="t.task.write",
+                layer=TemplateLayer.TASK,
                 template="Write something.",
             ),
         ]
@@ -111,7 +121,8 @@ class TestResponseFormatPropagation:
         schema = {"type": "object", "properties": {"name": {"type": "string"}}}
         templates = [
             PromptTemplate(
-                id="t.task.extract", layer=TemplateLayer.TASK,
+                id="t.task.extract",
+                layer=TemplateLayer.TASK,
                 template="Extract.",
                 output_schema=schema,
                 response_format="json_schema",
@@ -124,12 +135,14 @@ class TestResponseFormatPropagation:
         renderer = self._make_renderer()
         templates = [
             PromptTemplate(
-                id="t.task.first", layer=TemplateLayer.TASK,
+                id="t.task.first",
+                layer=TemplateLayer.TASK,
                 template="First.",
                 response_format="json_object",
             ),
             PromptTemplate(
-                id="t.task.second", layer=TemplateLayer.TASK,
+                id="t.task.second",
+                layer=TemplateLayer.TASK,
                 template="Second.",
                 response_format="text",
             ),
@@ -142,6 +155,7 @@ class TestResponseFormatPropagation:
 # Befund #5 — strict-Mode in TemplateRegistry
 # ---------------------------------------------------------------------------
 
+
 class TestRegistryStrictMode:
     def test_should_raise_on_missing_required_fields_in_strict_mode(self, tmp_path):
         bad_yaml = tmp_path / "bad.yaml"
@@ -151,9 +165,7 @@ class TestRegistryStrictMode:
 
     def test_should_raise_on_invalid_layer_in_strict_mode(self, tmp_path):
         bad_yaml = tmp_path / "bad_layer.yaml"
-        bad_yaml.write_text(
-            "id: test.task.bad\nlayer: nonexistent\ntemplate: Hello\n"
-        )
+        bad_yaml.write_text("id: test.task.bad\nlayer: nonexistent\ntemplate: Hello\n")
         with pytest.raises(ValueError, match="invalid layer"):
             TemplateRegistry.from_directory(tmp_path, strict=True)
 
@@ -174,9 +186,7 @@ class TestRegistryStrictMode:
 
     def test_should_load_valid_template_in_strict_mode(self, tmp_path):
         good_yaml = tmp_path / "good.yaml"
-        good_yaml.write_text(
-            "id: test.task.good\nlayer: task\ntemplate: Hello {{ name }}\n"
-        )
+        good_yaml.write_text("id: test.task.good\nlayer: task\ntemplate: Hello {{ name }}\n")
         registry = TemplateRegistry.from_directory(tmp_path, strict=True)
         assert len(registry) == 1
         assert registry.get("test.task.good").id == "test.task.good"
@@ -193,6 +203,7 @@ class TestRegistryStrictMode:
 # ---------------------------------------------------------------------------
 # Befund #6 — VALID_RESPONSE_FORMATS Konstante
 # ---------------------------------------------------------------------------
+
 
 class TestValidResponseFormats:
     def test_should_contain_json_object(self):

--- a/tests/test_think_tags.py
+++ b/tests/test_think_tags.py
@@ -1,5 +1,4 @@
 """Tests for <think> tag stripping in promptfw.parsing."""
-import pytest
 
 from promptfw.parsing import (
     extract_json,
@@ -17,16 +16,16 @@ class TestStripReasoningTags:
         assert strip_reasoning_tags(text) == '{"key": "value"}'
 
     def test_strips_reasoning_tags(self):
-        text = '<reasoning>\nStep 1...\n</reasoning>\nResult'
-        assert strip_reasoning_tags(text) == 'Result'
+        text = "<reasoning>\nStep 1...\n</reasoning>\nResult"
+        assert strip_reasoning_tags(text) == "Result"
 
     def test_strips_thought_tags(self):
-        text = '<thought>Hmm...</thought>Answer'
-        assert strip_reasoning_tags(text) == 'Answer'
+        text = "<thought>Hmm...</thought>Answer"
+        assert strip_reasoning_tags(text) == "Answer"
 
     def test_case_insensitive(self):
-        text = '<THINK>\nreasoning\n</THINK>\noutput'
-        assert strip_reasoning_tags(text) == 'output'
+        text = "<THINK>\nreasoning\n</THINK>\noutput"
+        assert strip_reasoning_tags(text) == "output"
 
     def test_no_tags_unchanged(self):
         text = '{"key": "value"}'
@@ -36,8 +35,8 @@ class TestStripReasoningTags:
         assert strip_reasoning_tags("") == ""
 
     def test_multiple_think_blocks(self):
-        text = '<think>first</think>middle<think>second</think>end'
-        assert strip_reasoning_tags(text) == 'middleend'
+        text = "<think>first</think>middle<think>second</think>end"
+        assert strip_reasoning_tags(text) == "middleend"
 
 
 class TestExtractJsonWithThinkTags:
@@ -49,10 +48,7 @@ class TestExtractJsonWithThinkTags:
         assert result == {"verdict": "accept"}
 
     def test_json_in_code_fence_after_think(self):
-        text = (
-            '<think>\nI need to format as JSON...\n</think>\n'
-            '```json\n{"score": 8}\n```'
-        )
+        text = '<think>\nI need to format as JSON...\n</think>\n```json\n{"score": 8}\n```'
         result = extract_json(text)
         assert result == {"score": 8}
 
@@ -69,14 +65,11 @@ class TestExtractJsonWithThinkTags:
 
     def test_think_block_containing_json(self):
         """JSON inside <think> should be ignored, only final output matters."""
-        text = (
-            '<think>\nIntermediate: {"wrong": true}\n</think>\n'
-            '{"correct": true}'
-        )
+        text = '<think>\nIntermediate: {"wrong": true}\n</think>\n{"correct": true}'
         result = extract_json(text)
         assert result == {"correct": True}
 
     def test_no_json_after_think_returns_none(self):
-        text = '<think>\nJust reasoning, no JSON output.\n</think>\nPlain text.'
+        text = "<think>\nJust reasoning, no JSON output.\n</think>\nPlain text."
         result = extract_json(text)
         assert result is None

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,7 +1,5 @@
 """Tests for promptfw writing templates and get_writing_stack."""
 
-import pytest
-
 from promptfw.schema import TemplateLayer
 from promptfw.stack import PromptStack
 from promptfw.writing import WRITING_TEMPLATES, get_writing_stack
@@ -34,7 +32,9 @@ class TestWritingTemplates:
             "writing.task.add_dialogue",
             "writing.task.summarize",
         }
-        assert expected == task_ids
+        # Subset, nicht Gleichheit: die Core-Task-Templates müssen vorhanden sein,
+        # ohne dass legitime Erweiterungen (z.B. Academic-Templates) den Test brechen.
+        assert expected <= task_ids, expected - task_ids
 
     def test_should_mark_system_templates_as_cacheable(self):
         for t in WRITING_TEMPLATES:
@@ -80,15 +80,18 @@ class TestGetWritingStack:
 
     def test_should_render_write_chapter_task(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.write_chapter", {
-            "chapter_number": 3,
-            "chapter_title": "Die Rückkehr",
-            "chapter_outline": "Der Held kehrt zurück und findet sein Dorf verändert.",
-            "target_words": 2500,
-            "pov_character": "Elias",
-            "mood": "melancholic",
-            "genre": "Fantasy",
-        })
+        rendered = stack.render(
+            "writing.task.write_chapter",
+            {
+                "chapter_number": 3,
+                "chapter_title": "Die Rückkehr",
+                "chapter_outline": "Der Held kehrt zurück und findet sein Dorf verändert.",
+                "target_words": 2500,
+                "pov_character": "Elias",
+                "mood": "melancholic",
+                "genre": "Fantasy",
+            },
+        )
         assert "3" in rendered.user
         assert "Die Rückkehr" in rendered.user
         assert "Elias" in rendered.user
@@ -96,13 +99,16 @@ class TestGetWritingStack:
 
     def test_should_render_write_chapter_with_optional_fields(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.write_chapter", {
-            "chapter_number": 1,
-            "chapter_title": "Aufbruch",
-            "chapter_outline": "Elias bricht auf.",
-            "story_premise": "Ein Schmied entdeckt seine Kräfte.",
-            "prior_chapter_summary": "Der Prolog endet mit einem Omen.",
-        })
+        rendered = stack.render(
+            "writing.task.write_chapter",
+            {
+                "chapter_number": 1,
+                "chapter_title": "Aufbruch",
+                "chapter_outline": "Elias bricht auf.",
+                "story_premise": "Ein Schmied entdeckt seine Kräfte.",
+                "prior_chapter_summary": "Der Prolog endet mit einem Omen.",
+            },
+        )
         assert "Ein Schmied" in rendered.user
         assert "Der Prolog" in rendered.user
 
@@ -121,45 +127,60 @@ class TestGetWritingStack:
 
     def test_should_render_improve_prose_task(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.improve_prose", {
-            "original_text": "Er ging schnell. Es war dunkel.",
-            "improvement_focus": "Rhythmus und Show-don't-tell",
-        })
+        rendered = stack.render(
+            "writing.task.improve_prose",
+            {
+                "original_text": "Er ging schnell. Es war dunkel.",
+                "improvement_focus": "Rhythmus und Show-don't-tell",
+            },
+        )
         assert "Er ging schnell" in rendered.user
         assert "Rhythmus" in rendered.user
 
     def test_should_render_summarize_task(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.summarize", {
-            "chapter_text": "Elias betrat die Stadt. Die Menschen sahen ihn misstrauisch an.",
-        })
+        rendered = stack.render(
+            "writing.task.summarize",
+            {
+                "chapter_text": "Elias betrat die Stadt. Die Menschen sahen ihn misstrauisch an.",
+            },
+        )
         assert "Elias betrat" in rendered.user
 
     def test_should_render_generate_outline_task(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.generate_outline", {
-            "chapter_number": 2,
-        })
+        rendered = stack.render(
+            "writing.task.generate_outline",
+            {
+                "chapter_number": 2,
+            },
+        )
         assert "2" in rendered.user
         assert "Eröffnungsszene" in rendered.user
 
     def test_should_render_add_dialogue_task(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.add_dialogue", {
-            "characters": "Elias, Maria",
-            "dialogue_purpose": "Verhandlung über das Schicksal des Dorfes",
-            "context_text": "Sie standen sich gegenüber.",
-        })
+        rendered = stack.render(
+            "writing.task.add_dialogue",
+            {
+                "characters": "Elias, Maria",
+                "dialogue_purpose": "Verhandlung über das Schicksal des Dorfes",
+                "context_text": "Sie standen sich gegenüber.",
+            },
+        )
         assert "Elias, Maria" in rendered.user
 
     def test_should_render_write_scene_task(self):
         stack = get_writing_stack()
-        rendered = stack.render("writing.task.write_scene", {
-            "scene_description": "Elias betritt die Schmiede im Morgengrauen.",
-            "characters": "Elias",
-            "location": "Dorfschmiede",
-            "mood": "hopeful",
-        })
+        rendered = stack.render(
+            "writing.task.write_scene",
+            {
+                "scene_description": "Elias betritt die Schmiede im Morgengrauen.",
+                "characters": "Elias",
+                "location": "Dorfschmiede",
+                "mood": "hopeful",
+            },
+        )
         assert "Elias" in rendered.user
         assert "Dorfschmiede" in rendered.user
 


### PR DESCRIPTION
**F4 CI-grün.** Enthält einen echten Bugfix (O1) + Config/Lint.

## Bug (O1): render_stack sortierte Context-Sub-Layer nicht
`renderer.render_stack` ist dokumentiert als *"automatically sorted by canonical layer order"*, mappte aber **alle** `USER_LAYERS` (CONTEXT_PROJECT/CHAPTER/SCENE/TASK) auf denselben Sort-Key `1`. Da `sorted` stabil ist, blieben die Sub-Layer in **Eingabe-Reihenfolge** → `test_should_render_context_sublayers_in_order` schlug fehl. Fix: voller `_canonical_order`-Index als Key.

## Weiteres
- `test_writing`: exakte Set-Gleichheit → **Subset** — legitime Academic-Template-Erweiterungen brachen den Test (F4-Churn-Quelle).
- CI: `3.11` aus Test-Matrix (Paket ist `requires-python>=3.12`); Install `.[dev,django]` damit `test_contrib_django` (ADR-146) läuft.
- ruff: E741-Renames (`l`→…), F841 toter Code, E401, format.

Lokal verifiziert: `ruff check .` + `ruff format --check .` clean, 248/248 pytest grün (inkl. django).

🤖 Generated with [Claude Code](https://claude.com/claude-code)