### PR TITLE
chore(agent-readiness): CLAUDE.md + AGENT_HANDOVER + __version__/classifiers + ruff target

### DIFF
--- a/AGENT_HANDOVER.md
+++ b/AGENT_HANDOVER.md
@@ -1,0 +1,51 @@
+# AGENT_HANDOVER — iil-promptfw
+
+> Living handover for the next agent/session. Keep this current; `NEXT.md` is an
+> auto-generated cache and is **not** the source of truth — this file is.
+
+## Current state (2026-06-22, observed)
+
+- Version: `pyproject.toml` = **0.8.1**; CHANGELOG top entry = 0.8.1.
+- Tests: green — `make test` → **251 passed** (1 warning), order-stable.
+- Lint: `ruff check src/ tests/` clean.
+- Types: no `[tool.mypy]` config, not part of the gate.
+- CI: `.github/workflows/` = `ci.yml`, `test.yml`, `publish.yml`,
+  `receive-windsurf-rules.yml`. `publish.yml` fires on `v*` tag or
+  `workflow_dispatch` (PyPI).
+- Package: `src/promptfw/`, ships `py.typed`, `__all__` declared.
+
+## Recently landed (this PR — agent-readiness, no behavior change)
+
+- `src/promptfw/__init__.py`: `__version__` now resolved from installed package
+  metadata (`importlib.metadata.version("iil-promptfw")`, fallback
+  `0.0.0.dev0`) instead of a hardcoded literal; added a public submodule-map
+  docstring. `__all__` was already present and is kept.
+- `pyproject.toml`: ruff `target-version` `py311` → `py312` (was a config-lie
+  against `requires-python >=3.12`); deduped the duplicate
+  `Programming Language :: Python :: 3.12` classifier and added the `3` parent.
+- Added `CLAUDE.md` (repo operating guide) and this `AGENT_HANDOVER.md`.
+- (Makefile already existed with working `test`/`lint`/`install`/`clean`.)
+
+## Known issues / TODO
+
+- **PyPI publish drift (priority, pre-existing — not touched here):** `pyproject`
+  is at `0.8.1` but **0.8.1 is not published** on PyPI. The `__init__.py` literal
+  had separately lagged at `0.7.0`, so the source had a three-way mismatch
+  (`__init__` 0.7.0 vs `pyproject` 0.8.1 vs published PyPI). This PR removes the
+  `__init__` source of drift (metadata-resolved version) but **deliberately does
+  not change the version number or run any publish** — the failed/absent publish
+  is a separate gated decision. Verify published version with
+  `pip index versions iil-promptfw` before deciding.
+- No `[tool.mypy]` config; no coverage floor configured.
+
+## Next priorities
+
+1. Decide/execute the gated `0.8.1` PyPI publish (resolves the publish drift).
+2. Introduce a `[tool.mypy]` config (start lenient) and a `types` make target.
+3. Add a coverage floor once suite coverage is measured.
+
+## Pointers
+
+- Architecture + commands: `CLAUDE.md`.
+- Public API surface: `src/promptfw/__init__.py` (`__all__`).
+- Changelog: `CHANGELOG.md` (Keep a Changelog).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md — iil-promptfw
+
+Operating guide for an AI agent working in this repo. Repo-specific; the
+user-level `~/.claude/CLAUDE.md` still applies and wins on conflicts.
+
+## What this is
+
+`iil-promptfw` (dist `iil-promptfw`, import `promptfw`) is a **5-layer Jinja2
+prompt template framework** for LLM applications. It registers `PromptTemplate`
+objects across the layers `SYSTEM → FORMAT → CONTEXT* → TASK → FEW_SHOT`,
+renders them through Jinja2 into a system + user prompt (`RenderedPrompt`), or
+directly into an OpenAI/LiteLLM message list. It adds wildcard lookup, version
+pinning, fallback chains, format-aware filtering, optional tiktoken token
+estimation, YAML/frontmatter loading, hot reload, LLM-response parsers, and an
+optional Django ORM adapter. Shipped as a pure-Python PyPI library (no CLI).
+
+## Setup
+
+```bash
+python3 -m pip install -e ".[dev]"   # editable install with dev extras
+```
+
+`__version__` is read from installed package metadata (`promptfw.__version__`);
+in a bare source checkout without an install it falls back to `0.0.0.dev0`.
+
+## Test / lint / types
+
+```bash
+make test     # python3 -m pytest tests/ --tb=short -q   (251 tests)
+make test-v   # same, verbose
+make lint     # ruff check src/ tests/
+make install  # pip install -e ".[dev]"
+make clean    # remove __pycache__ + .pytest_cache
+```
+
+- `pytest` config lives in `[tool.pytest.ini_options]`: `pythonpath = ["src"]`,
+  `asyncio_mode = "auto"`, `testpaths = ["tests"]`.
+- There is no committed `[tool.mypy]` config and no `types` target — type
+  checking is not part of the gate today.
+
+## Architecture (module map)
+
+| Module | Responsibility |
+|---|---|
+| `schema.py` | `PromptTemplate`, `RenderedPrompt`, `TemplateLayer`, `USER_LAYERS`, `to_messages()` |
+| `registry.py` | `TemplateRegistry` — wildcard lookup, version pinning, fallback chains |
+| `renderer.py` | `PromptRenderer` — Jinja2 rendering engine |
+| `stack.py` | `PromptStack` — high-level facade (register, render, render_to_messages, hot reload) |
+| `parsing.py` | `extract_json`, `extract_json_list`, `extract_json_strict`, `extract_field`, `<think>` stripping |
+| `frontmatter.py` | `render_frontmatter_file` / `render_frontmatter_string` (YAML frontmatter + body) |
+| `planning.py` | `get_planning_stack()` + `PLANNING_TEMPLATES` |
+| `writing.py` | `get_writing_stack` / `get_academic_writing_stack` / `get_scientific_writing_stack` |
+| `lektorat.py` | `get_lektorat_stack()` + `LEKTORAT_TEMPLATES` |
+| `concept_analysis.py` | `get_concept_analysis_stack()` + `CONCEPT_ANALYSIS_TEMPLATES` |
+| `db_resolver.py` | `DBPromptResolver` — DB-backed template resolution |
+| `django_registry.py` | `DjangoTemplateRegistry`, `BFAGENT_FIELD_MAP` — ORM adapter |
+| `contrib/django/` | optional Django app: models, admin, migrations, management commands |
+| `exceptions.py` | `TemplateNotFoundError`, `TemplateRenderError`, `LLMResponseError` |
+
+The public API surface is re-exported from `promptfw/__init__.py` (`__all__`).
+
+## Conventions
+
+- Commits: `[feat|fix|refactor|docs|test|chore](scope): description`.
+- Tests: `test_should_<expected_behavior>` (a pytest plugin nudges this; legacy
+  test names still exist).
+- Optional features degrade gracefully: `tiktoken`, `watchdog` (hotreload) and
+  `django`/`pydantic` are extras — code must not hard-import them at module top
+  level outside `contrib/`.
+
+## Release (gated — not on merge)
+
+Versioned in `pyproject.toml` + `CHANGELOG.md` (Keep a Changelog). Publishing to
+PyPI is a **deliberate, gated step** via `.github/workflows/publish.yml`
+(triggered by a `v*` tag push or `workflow_dispatch`) — never automatic on
+merge. Keep `pyproject.version`, the CHANGELOG top entry, and the published
+PyPI version in sync. Do not tag/publish without an explicit go-ahead.
+
+## Known issues / gotchas
+
+- **PyPI publish drift:** `pyproject` is at `0.8.1` but it is not published; the
+  `__init__.py` literal previously lagged at `0.7.0` (now resolved from metadata
+  instead of a literal). See `AGENT_HANDOVER.md`.
+- No `[tool.mypy]` config and no coverage floor configured.
+- See `AGENT_HANDOVER.md` for current state and next priorities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -73,4 +73,4 @@ asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py312"

--- a/src/promptfw/__init__.py
+++ b/src/promptfw/__init__.py
@@ -1,10 +1,34 @@
-"""
-promptfw — Prompt Template Framework
+"""promptfw — Prompt Template Framework.
 
-5-layer Jinja2 template engine for LLM applications.
+5-layer Jinja2 template engine for LLM applications: a registry of
+``PromptTemplate`` objects (SYSTEM / FORMAT / CONTEXT* / TASK / FEW_SHOT layers)
+that renders into system + user prompts or directly into OpenAI/LiteLLM message
+lists. The public API is re-exported here; the implementation lives in submodules:
+
+- ``promptfw.schema``           — ``PromptTemplate``, ``RenderedPrompt``, ``TemplateLayer``, ``USER_LAYERS``
+- ``promptfw.registry``         — ``TemplateRegistry`` (wildcard lookup, version pinning, fallback chains)
+- ``promptfw.renderer``         — ``PromptRenderer`` (Jinja2 rendering engine)
+- ``promptfw.stack``            — ``PromptStack`` (high-level facade: register, render, render_to_messages)
+- ``promptfw.parsing``          — ``extract_json``/``extract_field`` LLM-response parsers
+- ``promptfw.frontmatter``      — render Markdown files/strings with YAML frontmatter
+- ``promptfw.planning``         — ``get_planning_stack()`` + ``PLANNING_TEMPLATES``
+- ``promptfw.writing``          — writing/academic/scientific stacks
+- ``promptfw.lektorat``         — ``get_lektorat_stack()`` + ``LEKTORAT_TEMPLATES``
+- ``promptfw.concept_analysis`` — ``get_concept_analysis_stack()`` + templates
+- ``promptfw.db_resolver``      — ``DBPromptResolver`` (DB-backed template resolution)
+- ``promptfw.django_registry``  — ``DjangoTemplateRegistry`` ORM adapter
+- ``promptfw.contrib.django``   — optional Django app (models, admin, management commands)
+- ``promptfw.exceptions``       — ``TemplateNotFoundError``, ``TemplateRenderError``, ``LLMResponseError``
+
+``__version__`` is resolved from the installed package metadata.
 """
 
-__version__ = "0.7.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("iil-promptfw")
+except PackageNotFoundError:  # source checkout without an install
+    __version__ = "0.0.0.dev0"
 
 from promptfw.exceptions import LLMResponseError, TemplateNotFoundError, TemplateRenderError
 from promptfw.schema import (


### PR DESCRIPTION
Tier 1 — agent-readiness for `iil-promptfw` (import `promptfw`). Follows the
reference set by `achimdehnert/iil-adrfw` PR #11. **No behavior change.**

## Changes

- **`src/promptfw/__init__.py`** — `__version__` is now resolved from installed
  package metadata (`importlib.metadata.version("iil-promptfw")`, fallback
  `0.0.0.dev0`) instead of a hardcoded literal that had drifted to `0.7.0`.
  Added a public submodule-map docstring so an agent can introspect the API.
  `__all__` and `py.typed` were already present and are kept.
- **`pyproject.toml`** — ruff `target-version` `py311` → **`py312`** (it was a
  config-lie against `requires-python >=3.12`); deduped the duplicate
  `Programming Language :: Python :: 3.12` classifier and added the `3` parent.
  `requires-python` and the version number are **unchanged**.
- **`CLAUDE.md`** — repo operating guide: what / setup / test-lint / module map /
  conventions / release (publish is gated, not on-merge) / known issues.
- **`AGENT_HANDOVER.md`** — living current-state/next-priorities handover.

## Note (not addressed here, by design)

There is a separate **PyPI publish drift**: `pyproject` is at `0.8.1` but it is
not published (the `__init__` literal had separately lagged at `0.7.0`). This PR
removes the `__init__` source of that drift but does **not** change the version
or run any release — that publish is a gated decision (see `AGENT_HANDOVER.md`).

## Verification

- `make test` → **251 passed** (ruff clean, unchanged).
- `PYTHONPATH=src python3 -c "import promptfw; promptfw.__version__"` resolves
  from metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)