### PR TITLE
fix(ci): publish-Gate über test-Job verdrahten (needs: test)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
 
   build:
     name: Build distribution
+    needs: test
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Ziel
`publish.yml` hat einen Job `test` ("Tests (publish gate)"), der den PyPI-Upload **nicht** gatete: `build` ohne `needs: test`, `publish-pypi` nur `needs: build` → ein `v*`-Tag-Push hätte auch bei roten Tests publiziert.

## Änderung
Eine Zeile: `needs: test` an `build` → Kette `test → build → publish-pypi / publish-testpypi`. Identisch zum aifw-Fix (achimdehnert/aifw#26) und konsistent zu authoringfw/riskfw/weltenfw.

## Tests
YAML-Parse + Job-Graph verifiziert (`build.needs=='test'`, `publish-pypi.needs=='build'`). Kein Codepfad geändert.

## Risiken
Strikt sicherer (Gate wird strenger). Kein Einfluss auf Laufzeit-Code/bestehende Releases.

## Bezug
Fleet-Pattern "Publish-Gate ohne needs:test" (Stufe-1-Analyse). Schwester: aifw#26. ADR-226: Publish bleibt bewusst pro Repo, Gate unmittelbar vor Upload — dieser Fix verdrahtet genau das.

🤖 Generated with [Claude Code](https://claude.com/claude-code)