### PR TITLE
chore(repo-optimize): quick-win doc/config consistency fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install package + dev deps
         run: |
           pip install --upgrade pip
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install hatch
         run: pip install hatch
       - name: Read version from pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- `RenderedPrompt.to_messages()` — convert a rendered prompt to an OpenAI-style
+  message list (`fc9ddd3`).
+- ADR index `docs/adr/README.md`; note that `ADR-146` is a platform-level ADR.
+- `make format` target; `make lint` now mirrors CI (`ruff format --check`).
+
+### Changed
+- `__version__` is now derived from installed package metadata
+  (`importlib.metadata.version`) instead of a hardcoded string that drifted (#16).
+- `publish.yml` builds/tests on Python 3.12 (was 3.11) to match `requires-python >=3.12`.
+- Docs: `catalog-info.yaml` package-name `promptfw` → `iil-promptfw`, "4-layer" → "5-layer";
+  README context-sub-layer version tag `v0.8.1` → `v0.5.0`; ADR-003 status → Accepted.
+
+### Fixed
+- Publish workflow now actually gates the release on the test job (`needs: test`, #17).
+
+---
+
 ## [0.8.1] — 2026-04-23
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # promptfw — Developer Makefile
 
-.PHONY: install test test-v lint clean help
+.PHONY: install test test-v lint format clean help
 
 PYTHON := python3
 PIP    := pip
@@ -10,7 +10,8 @@ help:
 	@echo "  install   — pip install -e '.[dev]'"
 	@echo "  test      — pytest (quiet)"
 	@echo "  test-v    — pytest (verbose)"
-	@echo "  lint      — ruff check src/ tests/"
+	@echo "  lint      — ruff check + ruff format --check (mirrors CI)"
+	@echo "  format    — ruff format (auto-fix)"
 	@echo "  clean     — remove __pycache__ + .pytest_cache"
 
 install:
@@ -24,6 +25,10 @@ test-v:
 
 lint:
 	ruff check src/ tests/
+	ruff format --check .
+
+format:
+	ruff format .
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ rendered = stack.render("story.task.write", {
 # rendered.user    →  user prompt   (CONTEXT* + TASK layers)
 ```
 
-## 5-Layer Stack
+## Layer Stack (5 core layers + 3 context sub-layers)
 
 ```
 SYSTEM           → Role & base behaviour      (stable, cacheable)
 FORMAT           → Format-specific rules       (stable, cacheable)
 CONTEXT          → Generic runtime context     (dynamic)
-CONTEXT_PROJECT  → Project-level context       (dynamic, v0.8.1)
+CONTEXT_PROJECT  → Project-level context       (dynamic, v0.5.0)
 CONTEXT_CHAPTER  → Chapter-level context       (dynamic, v0.5.0)
 CONTEXT_SCENE    → Scene-level context         (dynamic, v0.5.0)
 TASK             → Concrete task               (dynamic)

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,11 +2,11 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: promptfw
-  description: Prompt Template Framework — 4-layer Jinja2 template engine for LLM applications
+  description: Prompt Template Framework — 5-layer Jinja2 template engine for LLM applications
   tags: [python, llm, templates, jinja2, framework]
   annotations:
     github.com/project-slug: achimdehnert/promptfw
-    pypi/package-name: "promptfw"
+    pypi/package-name: "iil-promptfw"
     pypi/publish-workflow: "publish.yml"
 spec:
   type: library

--- a/docs/adr/ADR-003-extension-roadmap.md
+++ b/docs/adr/ADR-003-extension-roadmap.md
@@ -2,7 +2,7 @@
 
 | Metadata | Value |
 |----------|-------|
-| **Status** | Proposed |
+| **Status** | Accepted (implemented — see `parsing.py`, `writing.py`, `lektorat.py`, `concept_analysis.py`) |
 | **Date** | 2026-03-01 |
 | **Author** | Achim Dehnert |
 | **Reviewers** | — |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records — promptfw
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](ADR-001-four-layer-prompt-stack.md) | Five-Layer Prompt Stack Architecture | Accepted |
+| [ADR-002](ADR-002-yaml-registry-vs-db-registry.md) | YAML Registry vs. DB Registry | Accepted |
+| [ADR-003](ADR-003-extension-roadmap.md) | Extension Roadmap (writing, lektorat, parsing, output_schema) | Accepted (implemented) |
+
+## External ADRs referenced by this repo
+
+Some modules (notably `src/promptfw/contrib/django/`) reference **ADR-146
+(DB-backed / hub prompt management)**. That ADR is **platform-level**, not local:
+
+- Canonical: `platform/docs/adr/ADR-146-hub-prompt-management.md`
+
+If you followed an `ADR-146` reference in a docstring and landed here, that is why —
+it is intentionally maintained at the platform level, not duplicated into this package.


### PR DESCRIPTION
Grounded quick-wins from `/repo-optimize` (2026-07-01). Full report: `~/shared/repo-optimize-promptfw-2026-07-01.md`.

All items are `[REPO-LOCAL]`, low-risk, docs/config only. No source-logic changes.

## Changes
- **catalog-info.yaml** — `pypi/package-name` `promptfw` → `iil-promptfw` (was pointing at a non-existent package); "4-layer" → "5-layer".
- **README** — context sub-layer version tag `v0.8.1` → `v0.5.0` (it shipped in 0.5.0, verified against CHANGELOG); layer-stack heading clarified to "5 core + 3 context sub-layers".
- **publish.yml** — build/test Python `3.11` → `3.12` to match `requires-python >=3.12`.
- **Makefile** — new `format` target; `lint` now also runs `ruff format --check` so local mirrors CI.
- **ADR-003** — status `Proposed` → `Accepted (implemented)`.
- **docs/adr/README.md** — new ADR index; documents that `ADR-146` is a platform-level ADR, resolving dangling references in `contrib/django` docstrings.
- **CHANGELOG** — added `[Unreleased]` covering `to_messages()`, version-derivation (#16), publish-gate (#17), and these fixes.

## Verification
- `make test` → **251 passed**
- `ruff check src/ tests/` → clean

## Not included (separate follow-ups, per report)
- SSTI hardening (H-03) → Issue + ADR proposal
- Parsing bugs (H-04/H-05), missing tests (M-07/08/09), CI dedup (H-08)
- Fleet patterns → `/platform-audit`