### PR TITLE
test: cover concept_analysis, db_resolver, and PromptStack (M-07/08/09)

### DIFF
--- a/tests/test_concept_analysis.py
+++ b/tests/test_concept_analysis.py
@@ -1,0 +1,96 @@
+"""Tests for promptfw concept-analysis templates and get_concept_analysis_stack."""
+
+from promptfw.concept_analysis import (
+    CONCEPT_ANALYSIS_TEMPLATES,
+    get_concept_analysis_stack,
+)
+from promptfw.schema import TemplateLayer
+from promptfw.stack import PromptStack
+
+
+class TestConceptAnalysisTemplates:
+    def test_should_expose_all_six_templates(self):
+        assert len(CONCEPT_ANALYSIS_TEMPLATES) == 6
+
+    def test_should_use_three_part_ids_prefixed_concept(self):
+        for tmpl in CONCEPT_ANALYSIS_TEMPLATES:
+            parts = tmpl.id.split(".")
+            assert len(parts) == 3, f"Template id '{tmpl.id}' must have 3 parts"
+            assert parts[0] == "concept"
+            assert parts[1] in {"system", "task"}
+
+    def test_should_mark_system_templates_cacheable(self):
+        for tmpl in CONCEPT_ANALYSIS_TEMPLATES:
+            if tmpl.layer == TemplateLayer.SYSTEM:
+                assert tmpl.cacheable is True, f"{tmpl.id} system template should be cacheable"
+
+    def test_should_mark_task_templates_not_cacheable(self):
+        for tmpl in CONCEPT_ANALYSIS_TEMPLATES:
+            if tmpl.layer == TemplateLayer.TASK:
+                assert tmpl.cacheable is False, f"{tmpl.id} task template should not be cacheable"
+
+    def test_should_have_analyst_and_structure_templates(self):
+        ids = {t.id for t in CONCEPT_ANALYSIS_TEMPLATES}
+        assert "concept.system.analyst" in ids
+        assert "concept.task.analyze_structure" in ids
+
+
+class TestGetConceptAnalysisStack:
+    def test_should_return_promptstack(self):
+        assert isinstance(get_concept_analysis_stack(), PromptStack)
+
+    def test_should_register_all_templates(self):
+        stack = get_concept_analysis_stack()
+        for tmpl in CONCEPT_ANALYSIS_TEMPLATES:
+            assert stack.registry.get(tmpl.id) is not None, f"{tmpl.id} not registered"
+
+    def test_should_render_analyst_system_in_german_by_default(self):
+        stack = get_concept_analysis_stack()
+        rendered = stack.render(
+            "concept.system.analyst",
+            {"scopes": "Brandschutz, Explosionsschutz", "language": "de"},
+        )
+        assert "Antworte immer auf Deutsch" in rendered.system
+        assert "Brandschutz" in rendered.system
+
+    def test_should_render_analyst_system_in_english_when_language_en(self):
+        stack = get_concept_analysis_stack()
+        rendered = stack.render(
+            "concept.system.analyst",
+            {"scopes": "fire safety", "language": "en"},
+        )
+        assert "Always respond in English" in rendered.system
+
+    def test_should_render_structure_task_with_document_fields(self):
+        stack = get_concept_analysis_stack()
+        rendered = stack.render(
+            "concept.task.analyze_structure",
+            {
+                "scope": "explosionsschutz",
+                "title": "Ex-Schutz Dokument 2024",
+                "page_count": 12,
+                "text": "Extrahierter Beispieltext.",
+            },
+        )
+        assert "Ex-Schutz Dokument 2024" in rendered.user
+        assert "explosionsschutz" in rendered.user
+        assert "Extrahierter Beispieltext." in rendered.user
+
+    def test_should_render_full_analysis_stack_with_system_and_user(self):
+        stack = get_concept_analysis_stack()
+        rendered = stack.render_stack(
+            ["concept.system.analyst", "concept.task.analyze_structure"],
+            context={
+                "scopes": "Brandschutz",
+                "language": "de",
+                "scope": "brandschutz",
+                "title": "Konzept A",
+                "page_count": 5,
+                "text": "...",
+            },
+        )
+        assert rendered.system != ""
+        assert "Konzept A" in rendered.user
+
+    def test_should_return_independent_stacks(self):
+        assert get_concept_analysis_stack() is not get_concept_analysis_stack()

--- a/tests/test_db_resolver.py
+++ b/tests/test_db_resolver.py
@@ -1,0 +1,116 @@
+"""Tests for promptfw.db_resolver.DBPromptResolver (Django-free DB prompt resolution)."""
+
+import pytest
+
+from promptfw.db_resolver import _GENERIC_SYSTEM, DBPromptResolver
+from promptfw.planning import get_planning_stack
+
+
+@pytest.fixture
+def resolver():
+    return DBPromptResolver(get_planning_stack())
+
+
+class TestLoadConfig:
+    def test_should_normalize_config_from_loader(self, resolver):
+        def loader(slug):
+            return {
+                "action_code": "planning_screenplay",
+                "template_prefix": "screenplay",
+                "system_prompt": "You are a screenwriter.",
+                "user_template": "Write {title}.",
+            }
+
+        cfg = resolver.load_config("screenplay", loader)
+        assert cfg["action_code"] == "planning_screenplay"
+        assert cfg["template_prefix"] == "screenplay"
+        assert cfg["system_prompt"] == "You are a screenwriter."
+
+    def test_should_fall_back_to_slug_when_prefix_missing(self, resolver):
+        cfg = resolver.load_config(
+            "mytale", lambda slug: {"action_code": "", "template_prefix": ""}
+        )
+        # empty template_prefix falls back to the slug, not the default prefix
+        assert cfg["template_prefix"] == "mytale"
+        assert cfg["action_code"] == "planning_novel"  # default_action_code
+
+    def test_should_use_defaults_when_loader_returns_none(self, resolver):
+        cfg = resolver.load_config("unknown", lambda slug: None)
+        assert cfg["action_code"] == "planning_novel"
+        assert cfg["template_prefix"] == "roman"
+        assert cfg["system_prompt"] == ""
+
+    def test_should_not_raise_when_loader_raises(self, resolver):
+        def broken_loader(slug):
+            raise RuntimeError("db down")
+
+        cfg = resolver.load_config("x", broken_loader)  # must never propagate
+        assert cfg["template_prefix"] == "roman"
+
+
+class TestBuildMessages:
+    def test_should_use_db_custom_prompts_when_both_set(self, resolver):
+        cfg = {
+            "action_code": "planning_novel",
+            "template_prefix": "roman",
+            "system_prompt": "SYS",
+            "user_template": "Book: {title}",
+        }
+        messages = resolver.build_messages(cfg, {"title": "Dune"})
+        assert messages == [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "Book: Dune"},
+        ]
+
+    def test_should_keep_raw_user_template_on_missing_format_key(self, resolver):
+        cfg = {
+            "action_code": "planning_novel",
+            "template_prefix": "roman",
+            "system_prompt": "SYS",
+            "user_template": "Book: {missing}",
+        }
+        # KeyError on .format(**context) must not crash — raw template kept
+        messages = resolver.build_messages(cfg, {"title": "Dune"})
+        assert messages[1]["content"] == "Book: {missing}"
+
+    def test_should_render_promptfw_stack_when_no_db_custom(self, resolver):
+        cfg = {
+            "action_code": "planning_novel",
+            "template_prefix": "roman",
+            "system_prompt": "",
+            "user_template": "",
+        }
+        messages = resolver.build_messages(
+            cfg,
+            {"title": "Der letzte Magier", "genre": "Fantasy", "description": "..."},
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert "Der letzte Magier" in messages[1]["content"]
+
+    def test_should_fall_back_to_generic_on_unknown_prefix(self, resolver):
+        cfg = {
+            "action_code": "planning_novel",
+            "template_prefix": "does-not-exist",
+            "system_prompt": "",
+            "user_template": "",
+        }
+        messages = resolver.build_messages(cfg, {"description": "A short brief."})
+        assert messages[0]["content"] == _GENERIC_SYSTEM
+        assert "A short brief." in messages[1]["content"]
+
+
+class TestResolve:
+    def test_should_return_action_code_and_messages(self, resolver):
+        action_code, messages = resolver.resolve(
+            "screenplay",
+            lambda slug: {
+                "action_code": "planning_screenplay",
+                "template_prefix": "screenplay",
+                "system_prompt": "SYS",
+                "user_template": "Title: {title}",
+            },
+            {"title": "Heat"},
+        )
+        assert action_code == "planning_screenplay"
+        assert messages[1]["content"] == "Title: Heat"

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,0 +1,90 @@
+"""Tests for the PromptStack façade: for_format, render_with_fallback, from_file, hot-reload."""
+
+import importlib.util
+
+import pytest
+
+from promptfw.exceptions import TemplateNotFoundError
+from promptfw.schema import PromptTemplate, TemplateLayer
+from promptfw.stack import PromptStack
+
+_HAS_WATCHDOG = importlib.util.find_spec("watchdog") is not None
+
+
+def _task(id_, template, format_type=None):
+    return PromptTemplate(
+        id=id_,
+        layer=TemplateLayer.TASK,
+        template=template,
+        format_type=format_type,
+    )
+
+
+class TestForFormat:
+    def test_should_keep_matching_and_format_agnostic_templates(self):
+        stack = PromptStack()
+        stack.register(_task("t.roman", "roman task", format_type="roman"))
+        stack.register(_task("t.essay", "essay task", format_type="essay"))
+        stack.register(_task("t.generic", "generic task", format_type=None))
+
+        filtered = stack.for_format("roman")
+        assert filtered.registry.get("t.roman") is not None
+        assert filtered.registry.get("t.generic") is not None  # None is always included
+        with pytest.raises(TemplateNotFoundError):
+            filtered.registry.get("t.essay")
+
+    def test_should_return_new_independent_stack(self):
+        stack = PromptStack()
+        stack.register(_task("t.roman", "x", format_type="roman"))
+        assert stack.for_format("roman") is not stack
+
+
+class TestRenderWithFallback:
+    def test_should_render_first_matching_pattern(self):
+        stack = PromptStack()
+        stack.register(_task("writing.task.default", "Default body"))
+        rendered = stack.render_with_fallback(
+            ["writing.task.write_chapter.roman", "writing.task.default"],
+            context={},
+        )
+        assert "Default body" in rendered.user
+
+    def test_should_raise_when_no_pattern_matches(self):
+        stack = PromptStack()
+        with pytest.raises(TemplateNotFoundError):
+            stack.render_with_fallback(["nope.a", "nope.b"], context={})
+
+
+class TestFromFile:
+    def test_should_raise_file_not_found_for_missing_path(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            PromptStack.from_file(tmp_path / "missing.yaml")
+
+    def test_should_reject_jinja2_files_pointing_to_frontmatter(self, tmp_path):
+        j2 = tmp_path / "tmpl.jinja2"
+        j2.write_text("hello")
+        with pytest.raises(ValueError, match="frontmatter"):
+            PromptStack.from_file(j2)
+
+
+class TestEnableHotReload:
+    def test_should_delegate_to_registry(self, mocker):
+        stack = PromptStack()
+        spy = mocker.patch.object(stack.registry, "enable_hot_reload")
+        stack.enable_hot_reload()
+        spy.assert_called_once_with()
+
+    @pytest.mark.skipif(
+        _HAS_WATCHDOG, reason="watchdog installed; ImportError branch not exercised"
+    )
+    def test_should_raise_helpful_import_error_without_watchdog(self, tmp_path):
+        stack = PromptStack.from_directory(tmp_path)
+        with pytest.raises(ImportError, match="watchdog"):
+            stack.enable_hot_reload()
+
+    @pytest.mark.skipif(not _HAS_WATCHDOG, reason="requires watchdog")
+    def test_should_start_observer_when_watchdog_available(self, tmp_path, mocker):
+        observer = mocker.patch("watchdog.observers.Observer")
+        stack = PromptStack.from_directory(tmp_path)
+        stack.enable_hot_reload()
+        observer.return_value.start.assert_called_once()


### PR DESCRIPTION
Adds tests for three public exports/methods that had **zero test coverage** — from `/repo-optimize` findings M-07/M-08/M-09 (report: `~/shared/repo-optimize-promptfw-2026-07-01.md`). Tests only; no source changes.

## New test files
- **tests/test_concept_analysis.py** — template constants (3-part ids, system-cacheable / task-not-cacheable contract), stack registration, German/English `language` switch, structure-task rendering with document fields, full-stack render.
- **tests/test_db_resolver.py** — `load_config` normalization / slug-fallback / defaults / never-raises-on-loader-error; `build_messages` full three-tier chain (DB custom → promptfw stack → generic fallback); `KeyError`-safe `.format`; `resolve()` returns `(action_code, messages)`.
- **tests/test_stack.py** — `for_format` filtering (incl. format-agnostic inclusion), `render_with_fallback` first-match + not-found, `from_file` FileNotFound + `.jinja2` rejection, `enable_hot_reload` delegation + `watchdog` ImportError contract (observer path gated by `skipif` so it never flakes when `watchdog` is absent).

## Verification
- `make test` → **280 passed, 1 skipped** (+29 vs. main's 251)
- `ruff check src/ tests/` clean · `ruff format --check .` clean

All new tests follow the `test_should_*` convention (does not add to the M-17 naming backlog).