### PR TITLE
chore(ci): shared-ci auf v1.0.11 bumpen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.8
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.11
     with:
       python_versions: '["3.12"]'
       install_extra: 'dev'


### PR DESCRIPTION
Bump aller `shared-ci@vX.X.X`-Referenzen auf **v1.0.11** — behebt In-Repo-Drift (ci.yml vs. deploy.yml oft unterschiedlich gepinnt) und bringt gate-Job (_ci-pypi), pytest_workers-Default-Fix und Stub-Warnung.

Vorheriger niedrigster Pin: **v1.0.8**.


Teil von KONZ-017 W2-1 (Bump-Welle): https://github.com/achimdehnert/platform/pull/1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)