### PR TITLE
feat(fleet): Freshness-Deklaration [tool.iil-fleet] als Pilot (KONZ-018 W1-3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,26 @@ asyncio_mode = "auto"
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+
+# Freshness-Deklaration (platform:KONZ-018 W1-3, Pilot — generalisiert das
+# produktive aifw-Muster aus install-iil-packages). Der generische Probe-Step
+# in der Consumer-CI liest diese Sektion (Fetch von origin/main) und prüft:
+# ist iil-promptfw >= freshness_min_version installiert, MUSS das importierte
+# Modul jedes Symbol exportieren — sonst ist der Tool-Cache-Code STALE.
+# Pflege-Regel (konservativ, R3): nur stabile Top-Level-API listen; ein neues
+# Symbol erst aufnehmen, wenn das Release, das es einführt, publiziert ist —
+# dann freshness_min_version auf dieses Release anheben.
+[tool.iil-fleet]
+freshness_min_version = "0.8"
+freshness_symbols = [
+    "PromptStack",
+    "PromptTemplate",
+    "RenderedPrompt",
+    "TemplateLayer",
+    "TemplateRegistry",
+    "PromptRenderer",
+    "TemplateNotFoundError",
+    "TemplateRenderError",
+    "extract_json",
+    "extract_field",
+]


### PR DESCRIPTION
## Ziel (platform:KONZ-018 W1-3 — Freshness-Pilot, Paket-Seite)

Generalisiert das produktive aifw-Freshness-Muster aus `install-iil-packages`: iil-promptfw (2.-größtes Paket, ~14 Konsumenten) deklariert seine stabile Top-Level-API selbst — als `[tool.iil-fleet]`-Sektion in `pyproject.toml`:

- `freshness_min_version = "0.8"` — nur Installationen mit Metadata >= 0.8 werden geprüft
- `freshness_symbols` — 10 konservativ gewählte, stabile Top-Level-Symbole (alle in `__all__`)

Der generische Probe-Step auf Consumer-Seite (Schwester-PR in shared-ci: `install-iil-packages`) liest diese Deklaration und failt laut, wenn ein installiertes iil-promptfw >= 0.8 die Symbole nicht exportiert (Stale-Tool-Cache-Klasse, s. platform#419).

## Verifikation

- `make test`: 251 passed (lokal, Repo-Konvention).
- TOML parst (`tomllib`).
- **Publizierte Wheels gegengeprüft** (R3-Absicherung gegen sofortiges Consumer-Rot): `iil-promptfw==0.8.0` und `==0.6.0` aus PyPI installiert — beide exportieren alle 10 deklarierten Symbole (`missing: []`).

## Pflege-Regel (im pyproject-Kommentar verankert)

Neues Symbol erst listen, wenn das einführende Release publiziert ist; dann `freshness_min_version` auf dieses Release anheben. Die aifw-Sonderlogik in der install-Action bleibt unangetastet, bis der Pilot grün ist (KONZ-018 W1-3).

## Nebenbefund (nicht Teil dieses PRs)

PyPI hat iil-promptfw nur bis **0.8.0** — `pyproject` auf main steht auf 0.8.1 und Tag `v0.8.1` existiert, aber das Release wurde nie hochgeladen (gleiche Klasse wie outlinefw/weltenfw, KONZ-018 C13 / Owner-Block W0-3).

Bezug: platform `docs/konzepte/KONZ-platform-018-pypi-fleet-predictive-standard-funktional.md` §5.5 W1-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
