### PR TITLE
fix(ci): publish.yml auf OIDC Trusted Publishing umstellen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 
   publish-testpypi:


### PR DESCRIPTION
## Was

Entfernt den `password: ${{ secrets.PYPI_API_TOKEN }}`-Input aus dem
`publish-pypi`-Step in `.github/workflows/publish.yml` → reines **OIDC
Trusted Publishing**.

## Warum

- Alle `publish.yml`-Runs seit 2026-03 rot: `403 Forbidden – Invalid or
  non-existent authentication information` von upload.pypi.org.
- Ursache: der explizite `password:`-Input **deaktiviert** Trusted Publishing
  (pypa-Action-Warnung „disabling Trusted Publishing") und nutzt stattdessen
  ein ungültiges/fehlendes Token.
- `id-token: write` + `environment: pypi` sind bereits gesetzt — der Workflow
  war OIDC-fertig bis auf diese eine Zeile.
- PyPI-Trusted-Publisher-Bindung ist angelegt: `achimdehnert/promptfw` →
  `publish.yml`, Environment `pypi` (Owner 2026-07-19).

## Effekt

- `attestations: true` wird nicht mehr ignoriert.
- Publish von 0.8.1 (Build + twine-check bereits grün) danach per
  `workflow_dispatch` (target=pypi) möglich — der v0.8.1-Tag hatte nie
  gefeuert.

## Kontext

- platform#1094 (KONZ-018 W0-3), ADR-266 (PyPI-Fleet OIDC-Readiness).
- Muster 1:1 auf die weiteren 6 Nicht-pur-OIDC-Repos übertragbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
