### PR TITLE
test(ci): TEMP @main — Guard-Verifikation (NICHT mergen)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.11
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@main
     with:
       python_versions: '["3.12"]'
       install_extra: 'dev'


### PR DESCRIPTION
Wegwerf-PR zur Verifikation des publish-auth-guard (ADR-278/shared-ci#32) auf einem echten Consumer. Zeigt `_ci-pypi.yml@main` statt `@v1.0.11`. **Nicht mergen** — wird nach Guard-Verifikation geschlossen; promptfw bleibt auf Tag-Pin.