### PR TITLE
chore(ci): shared-ci v1.0.11 → v1.0.13 (publish-auth-guard, ADR-278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.11
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.13
     with:
       python_versions: '["3.12"]'
       install_extra: 'dev'


### PR DESCRIPTION
Bump auf shared-ci **v1.0.13** — bringt den warn-first `publish-auth-guard` (ADR-278, shared-ci#32) auf diesen tag-gepinnten Consumer. Non-blocking (continue-on-error, nicht in gate.needs). promptfw ist bereits OIDC-only → Guard meldet grün.