### PR TITLE
chore(ci): shared-ci v1.0.14 (publish-auth-guard block, ADR-278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.13
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.14
     with:
       python_versions: '["3.12"]'
       install_extra: 'dev'


### PR DESCRIPTION
Bump auf shared-ci **v1.0.14** — scharfgeschalteter `publish-auth-guard` (block, ADR-278). promptfw ist OIDC → Guard grün, Gate bleibt grün.