### PR TITLE
ci: CI-Anbieter vereinheitlicht auf iilgmbh/shared-ci@v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.0.14
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.1.0
     with:
       python_versions: '["3.12"]'
       install_extra: 'dev'

--- a/.github/workflows/handoff-banner-gate.yml
+++ b/.github/workflows/handoff-banner-gate.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   handoff-banner:
-    uses: achimdehnert/platform/.github/workflows/handoff-banner-gate.yml@main
+    uses: iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.0


### PR DESCRIPTION
Ein Anbieter statt drei. Teil des Rückbaus aus [platform#1680](https://github.com/achimdehnert/platform/issues/1680).

## Was sich ändert

Die CI-Workflows kommen jetzt aus [`iilgmbh/shared-ci@v1.1.0`](https://github.com/iilgmbh/shared-ci) — statt aus `achimdehnert/platform` (oft ungepinnt auf `@main`), aus `achimdehnert/shared-ci` (heute versehentlich entstanden) oder aus einem alten `shared-ci`-Tag.

## Warum

**Es gab nie zwei Anforderungen, nur zwei Pflegestände.** Ein Vollzensus über alle 72 Repos der vier Owner-Namensräume zeigte: dieselben Jobs, dieselben Schritte, unterschiedliche Action-Versionen. `v1.1.0` vereinigt beide Linien auf dem neueren Stand.

| Action | vorher | jetzt |
|---|---|---|
| `actions/checkout` | v6 | **v7** |
| `actions/setup-python` | v6 | **v7** |
| `docker/metadata-action` | v5 | **v6** |
| `aquasecurity/trivy-action` | **`@master`** | **v0.36.0** |

Der letzte war ein ungepinnter Verweis auf einen beweglichen Branch — in jedem Docker-Build, seit zwei Monaten.

Entfernt wurden zwei Sonderwege ohne fachlichen Grund: `skip_external_verify` (gebaut für ein Repo, das gar keinen Deploy hat) und `ghcr_push_token` (das Package war längst mit dem Repo verknüpft; der Standard-`GITHUB_TOKEN` reicht — am 2026-08-02 mit einem echten Build belegt).

## Wenn hier etwas rot wird

Der Rückweg ist ein Revert dieses PRs. Bitte **nicht** mergen, solange die CI rot ist — der Sinn der Welle ist, dass jedes Repo einzeln beweist, dass der Wechsel trägt.