### PR TITLE
ci(handover): Gate-Pin auf einen festen Tag (platform#1962)

### DIFF
--- a/.github/workflows/handoff-banner-gate.yml
+++ b/.github/workflows/handoff-banner-gate.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   handoff-banner:
-    uses: iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.0
+    uses: iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.7


### PR DESCRIPTION
Vereinheitlicht den Pin des Frische-Gates `handover-stale-vor-merge` auf `@v1.1.7`. Schritt 3 aus [achimdehnert/platform#1962](https://github.com/achimdehnert/platform/issues/1962).

## Ausgangslage

Die verdrahteten Repos referenzierten denselben Workflow in fünf Fassungen: `@v1.1.0` (8×), `@v1.1.2` (2×), `@v1.1.1`, `@v1.1.5` — dazu drei auf `@main` und einer auf einem SHA, den GitHub nicht mehr auflösen konnte. Die letzten vier sind bereits gerichtet; dieser PR schließt die Versionsspreizung.

## Verhaltensrisiko: null, und zwar nachgemessen

Die Gate-Datei ist über **alle fünf Tags byte-identisch** — gleicher md5 `209e23cd5845` für `v1.1.0`, `v1.1.1`, `v1.1.2`, `v1.1.5` und `v1.1.7`. Der Bump ändert kein Verhalten, er vereinheitlicht nur, was man liest.

Der eigentliche Grund, warum die Tag-Nummer hier ohnehin wenig aussagt: der Workflow lädt seine Prüfskripte per zweitem Checkout **ohne `ref:`** —

```yaml
- name: Check-Skripte aus platform laden
  uses: actions/checkout@v7
  with:
    repository: iilgmbh/shared-ci
    sparse-checkout: |
      scripts/checks
```

— also immer vom Default-Branch. Der Pin friert die YAML ein, nicht die Logik. Wer glaubt, mit einem Tag die Prüfregeln festzunageln, irrt; das ist in #1962 als eigener Punkt festgehalten und **nicht** Teil dieses PRs.

## Warum überhaupt vereinheitlichen, wenn es egal ist

Weil „egal" heute gilt und nicht morgen. Sobald die Gate-Datei sich zwischen Tags unterscheidet, wird aus der Spreizung stiller Drift — und niemand sieht einer Sammlung aus `@v1.1.0`, `@v1.1.2` und `@v1.1.5` an, welche davon die gewollte ist. Ein einheitlicher Tag macht die nächste echte Änderung sichtbar.

## Risiko

Eine Zeile in einer Workflow-Datei. Der Workflow läuft nur auf `pull_request` mit `contents: read`. Rücknahme ist ein `git revert`.
