### PR TITLE
chore(ci): shared-ci v1.1.11 + Kanon-Kommentar (platform#2075 K3/M4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # ci.yml — Thin-Caller auf das ADR-226-Reusable (platform ADR-266 Stufe 2b).
 # Semantik (Lint, Secret-Scan, Test+Coverage, Build+Artefakt-Scan, pip-audit)
-# lebt zentral in platform/.github/workflows/_ci-pypi.yml — Verbesserungen
+# lebt zentral in iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml — Verbesserungen
 # erreichen alle Pakete in O(1). Inputs abgeleitet aus der Vorgänger-ci.yml.
 
 name: CI
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.1.0
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-pypi.yml@v1.1.11
     with:
       python_versions: '["3.12"]'
       install_extra: 'dev'

--- a/.github/workflows/handoff-banner-gate.yml
+++ b/.github/workflows/handoff-banner-gate.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   handoff-banner:
-    uses: iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.7
+    uses: iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.11


### PR DESCRIPTION
M4-Remediation aus dem Fruehwarn-Scan (platform docs/verifications/2026-08-19-adr266-earlywarn-baseline.md): shared-ci-Pins auf den neuesten Tag v1.1.11; Kommentar-Header zeigt auf den neuen Kanon iilgmbh/shared-ci (ADR-226 Amendment 2026-08-19, platform#2084). Zahlt auf achimdehnert/platform#2075 K3 ein.